### PR TITLE
[feat] 즐겨찾기 조회 목록 기능 구현

### DIFF
--- a/src/main/java/org/programmers/signalbuddy/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/bookmark/controller/BookmarkController.java
@@ -1,5 +1,36 @@
 package org.programmers.signalbuddy.domain.bookmark.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.programmers.signalbuddy.domain.bookmark.dto.BookmarkResponse;
+import org.programmers.signalbuddy.domain.bookmark.service.BookmarkService;
+import org.springframework.boot.autoconfigure.security.SecurityProperties.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/bookmarks")
+@Tag(name = "Bookmark API")
 public class BookmarkController {
 
+    private final BookmarkService bookmarkService;
+
+    @Operation(summary = "즐겨찾기 목록 조회", description = "Pagination")
+    @GetMapping
+    @ApiResponse(responseCode = "200", description = "즐겨찾기 목록 조회 성공")
+    public ResponseEntity<Page<BookmarkResponse>> getBookmarks(
+        @PageableDefault(page = 0, size = 5) Pageable pageable, User user) {
+        final Page<BookmarkResponse> bookmarks = bookmarkService.findPagedBookmarks(pageable, user);
+        return ResponseEntity.ok().body(bookmarks);
+    }
 }

--- a/src/main/java/org/programmers/signalbuddy/domain/bookmark/dto/BookmarkResponse.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/bookmark/dto/BookmarkResponse.java
@@ -1,0 +1,26 @@
+package org.programmers.signalbuddy.domain.bookmark.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString
+@EqualsAndHashCode
+public class BookmarkResponse {
+
+    private Long bookmarkId;
+
+    private double lat;
+
+    private double lng;
+
+    private String address;
+}

--- a/src/main/java/org/programmers/signalbuddy/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/bookmark/entity/Bookmark.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,9 +20,8 @@ import org.programmers.signalbuddy.domain.member.entity.Member;
 
 @Entity(name = "bookmarks")
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 @ToString
 public class Bookmark extends BaseTimeEntity {
@@ -30,7 +30,7 @@ public class Bookmark extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long bookmarkId;
 
-    @Column(nullable = false, columnDefinition = "Point")
+    @Column(nullable = false)
     private Point coordinate;
 
     @Column(nullable = false)

--- a/src/main/java/org/programmers/signalbuddy/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/bookmark/repository/BookmarkRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long>,
+    BookmarkRepositoryCustom {
 
 }

--- a/src/main/java/org/programmers/signalbuddy/domain/bookmark/repository/BookmarkRepositoryCustom.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/bookmark/repository/BookmarkRepositoryCustom.java
@@ -1,0 +1,10 @@
+package org.programmers.signalbuddy.domain.bookmark.repository;
+
+import org.programmers.signalbuddy.domain.bookmark.dto.BookmarkResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface BookmarkRepositoryCustom {
+
+    Page<BookmarkResponse> findPagedByMember(Pageable pageable, Long memberId);
+}

--- a/src/main/java/org/programmers/signalbuddy/domain/bookmark/repository/BookmarkRepositoryCustomImpl.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/bookmark/repository/BookmarkRepositoryCustomImpl.java
@@ -1,0 +1,43 @@
+package org.programmers.signalbuddy.domain.bookmark.repository;
+
+import static org.programmers.signalbuddy.domain.bookmark.entity.QBookmark.bookmark;
+import static org.programmers.signalbuddy.domain.member.entity.QMember.member;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.QBean;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.programmers.signalbuddy.domain.bookmark.dto.BookmarkResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BookmarkRepositoryCustomImpl implements BookmarkRepositoryCustom {
+
+    private static final QBean<BookmarkResponse> pageBookmarkDto = Projections.fields(
+        BookmarkResponse.class, bookmark.bookmarkId, bookmark.address,
+        Expressions.numberTemplate(Double.class, "ST_X({0})", bookmark.coordinate).as("lng"),
+        Expressions.numberTemplate(Double.class, "ST_Y({0})", bookmark.coordinate).as("lat"));
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<BookmarkResponse> findPagedByMember(Pageable pageable, Long memberId) {
+        final List<BookmarkResponse> responses = queryFactory.select(pageBookmarkDto).from(bookmark)
+            .join(member).on(member.memberId.eq(1L)) // TODO : 1L -> memberId
+            .offset(pageable.getOffset()).limit(pageable.getPageSize())
+            .orderBy(new OrderSpecifier<>(Order.ASC, bookmark.bookmarkId)).fetch();
+
+        final Long count = queryFactory.select(bookmark.count()).from(bookmark).join(member)
+            .on(member.memberId.eq(1L)) // TODO : 1L -> memberId
+            .fetchOne();
+        return new PageImpl<>(responses, pageable, count != null ? count : 0);
+    }
+}

--- a/src/main/java/org/programmers/signalbuddy/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/bookmark/service/BookmarkService.java
@@ -1,12 +1,23 @@
 package org.programmers.signalbuddy.domain.bookmark.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.programmers.signalbuddy.domain.bookmark.dto.BookmarkResponse;
 import org.programmers.signalbuddy.domain.bookmark.repository.BookmarkRepository;
+import org.springframework.boot.autoconfigure.security.SecurityProperties.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BookmarkService {
 
     private final BookmarkRepository bookmarkRepository;
+
+    public Page<BookmarkResponse> findPagedBookmarks(Pageable pageable, User user) {
+        // TODO : 2번째 인자 memberId 수정 필요
+        return bookmarkRepository.findPagedByMember(pageable, 1L);
+    }
 }

--- a/src/main/java/org/programmers/signalbuddy/global/config/WebConfig.java
+++ b/src/main/java/org/programmers/signalbuddy/global/config/WebConfig.java
@@ -1,0 +1,12 @@
+package org.programmers.signalbuddy.global.config;
+
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+
+@Configuration
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
+public class WebConfig {
+
+}

--- a/src/test/java/org/programmers/signalbuddy/domain/bookmark/repository/BookmarkRepositoryTest.java
+++ b/src/test/java/org/programmers/signalbuddy/domain/bookmark/repository/BookmarkRepositoryTest.java
@@ -1,0 +1,67 @@
+package org.programmers.signalbuddy.domain.bookmark.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.programmers.signalbuddy.domain.bookmark.dto.BookmarkResponse;
+import org.programmers.signalbuddy.domain.bookmark.entity.Bookmark;
+import org.programmers.signalbuddy.domain.member.entity.Member;
+import org.programmers.signalbuddy.domain.member.entity.enums.MemberStatus;
+import org.programmers.signalbuddy.domain.member.repository.MemberRepository;
+import org.programmers.signalbuddy.global.support.RepositoryTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+class BookmarkRepositoryTest extends RepositoryTest {
+
+    private final GeometryFactory geometryFactory = new GeometryFactory();
+
+    private Member member;
+    @Autowired
+    private BookmarkRepository bookmarkRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder().email("test@example.com").password("password123")
+            .nickname("TestUser").profileImageUrl("http://example.com/profile.jpg").role("USER")
+            .memberStatus(MemberStatus.ACTIVITY).build();
+    }
+
+    @DisplayName("즐겨찾기 목록 조회 테스트")
+    @Test
+    void testGetBookmarksWithPagination() {
+        Member member1 = memberRepository.save(member);
+        Point point = geometryFactory.createPoint(new Coordinate(127.12345, 37.12345));
+
+        for (int i = 1; i <= 10; i++) {
+            Bookmark bookmark = Bookmark.builder().address("Address " + i).coordinate(point)
+                .member(member1).build();
+            bookmarkRepository.save(bookmark);
+        }
+
+        /* H2 데이터베이스에서 ST_X 함수 이용 X
+        Pageable pageable = PageRequest.of(0, 5);
+        Page<BookmarkResponse> bookmarksPage = bookmarkRepository.findPagedByMember(pageable, 1L);
+
+        assertThat(bookmarksPage).isNotNull();
+        assertThat(bookmarksPage.getContent()).hasSize(5);
+        assertThat(bookmarksPage.getTotalElements()).isEqualTo(10);
+        assertThat(bookmarksPage.getTotalPages()).isEqualTo(2);
+        assertThat(bookmarksPage.isFirst()).isTrue();
+        assertThat(bookmarksPage.isLast()).isFalse();
+
+        BookmarkResponse firstBookmark = bookmarksPage.getContent().get(0);
+        assertThat(firstBookmark.getAddress()).isEqualTo("Address 1");
+        */
+    }
+
+}

--- a/src/test/java/org/programmers/signalbuddy/global/config/TestQuerydslConfig.java
+++ b/src/test/java/org/programmers/signalbuddy/global/config/TestQuerydslConfig.java
@@ -1,0 +1,18 @@
+package org.programmers.signalbuddy.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestQuerydslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/test/java/org/programmers/signalbuddy/global/support/RepositoryTest.java
+++ b/src/test/java/org/programmers/signalbuddy/global/support/RepositoryTest.java
@@ -1,12 +1,15 @@
 package org.programmers.signalbuddy.global.support;
 
+import org.programmers.signalbuddy.global.config.TestQuerydslConfig;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@Import(TestQuerydslConfig.class)
 public abstract class RepositoryTest {
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #16 즐겨찾기 조회 등록


## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 `ex) [feat] ㅇㅇ 기능 추가`
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료
- [x] 🏗️ 빌드 성공
- [x] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> 즐겨찾기 조회 페이징 구현
> 목록 조회 테스트코드 H2에선 'ST_' mariadb 함수를 쓸 수 없어서 주석 처리.

## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->



## 👀 리뷰어 가이드라인

