### PR TITLE
[feature] 피드백 목록 조회 상세 조회

### DIFF
--- a/src/main/java/org/programmers/signalbuddy/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/feedback/controller/FeedbackController.java
@@ -7,10 +7,14 @@ import lombok.RequiredArgsConstructor;
 import org.programmers.signalbuddy.domain.feedback.dto.FeedbackResponse;
 import org.programmers.signalbuddy.domain.feedback.dto.FeedbackWriteRequest;
 import org.programmers.signalbuddy.domain.feedback.service.FeedbackService;
+import org.programmers.signalbuddy.global.dto.PageResponse;
 import org.springframework.boot.autoconfigure.security.SecurityProperties.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,6 +29,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class FeedbackController {
 
     private final FeedbackService feedbackService;
+
+    @Operation(summary = "피드백 목록")
+    @GetMapping
+    public ResponseEntity<PageResponse<FeedbackResponse>> searchFeedbackList(
+        @PageableDefault(page = 0, size = 10) Pageable pageable) {
+        return ResponseEntity.ok().body(feedbackService.searchFeedbackList(pageable));
+    }
 
     @Operation(summary = "피드백 작성")
     @PostMapping("/write")

--- a/src/main/java/org/programmers/signalbuddy/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/feedback/controller/FeedbackController.java
@@ -37,6 +37,13 @@ public class FeedbackController {
         return ResponseEntity.ok().body(feedbackService.searchFeedbackList(pageable));
     }
 
+    @Operation(summary = "피드백 상세 조회")
+    @GetMapping("/{feedbackId}")
+    public ResponseEntity<FeedbackResponse> searchFeedbackDetail(
+        @PathVariable("feedbackId") Long feedbackId) {
+        return ResponseEntity.ok().body(feedbackService.searchFeedbackDetail(feedbackId));
+    }
+
     @Operation(summary = "피드백 작성")
     @PostMapping("/write")
     public ResponseEntity<FeedbackResponse> writeFeedback(

--- a/src/main/java/org/programmers/signalbuddy/domain/feedback/dto/FeedbackMapper.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/feedback/dto/FeedbackMapper.java
@@ -3,6 +3,7 @@ package org.programmers.signalbuddy.domain.feedback.dto;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 import org.programmers.signalbuddy.domain.feedback.entity.Feedback;
+import org.programmers.signalbuddy.domain.member.dto.MemberResponse;
 import org.programmers.signalbuddy.domain.member.entity.Member;
 
 @Mapper
@@ -10,7 +11,7 @@ public interface FeedbackMapper {
 
     FeedbackMapper INSTANCE = Mappers.getMapper(FeedbackMapper.class);
 
-    FeedbackResponse.MemberResponse toMemberResponse(Member member);
+    MemberResponse toMemberResponse(Member member);
 
     FeedbackResponse toResponse(Feedback feedback);
 }

--- a/src/main/java/org/programmers/signalbuddy/domain/feedback/dto/FeedbackMapper.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/feedback/dto/FeedbackMapper.java
@@ -3,11 +3,14 @@ package org.programmers.signalbuddy.domain.feedback.dto;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 import org.programmers.signalbuddy.domain.feedback.entity.Feedback;
+import org.programmers.signalbuddy.domain.member.entity.Member;
 
 @Mapper
 public interface FeedbackMapper {
 
     FeedbackMapper INSTANCE = Mappers.getMapper(FeedbackMapper.class);
+
+    FeedbackResponse.MemberResponse toMemberResponse(Member member);
 
     FeedbackResponse toResponse(Feedback feedback);
 }

--- a/src/main/java/org/programmers/signalbuddy/domain/feedback/dto/FeedbackResponse.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/feedback/dto/FeedbackResponse.java
@@ -1,13 +1,16 @@
 package org.programmers.signalbuddy.domain.feedback.dto;
 
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import org.programmers.signalbuddy.domain.member.entity.Member;
+import lombok.NoArgsConstructor;
+import org.programmers.signalbuddy.domain.member.entity.enums.MemberStatus;
 
 @Getter
 @Builder
+@NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class FeedbackResponse {
 
@@ -15,5 +18,19 @@ public class FeedbackResponse {
     private String subject;
     private String content;
     private Long likeCount;
-    private Member member;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private MemberResponse member;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class MemberResponse {
+        private Long memberId;
+        private String nickname;
+        private String profileImageUrl;
+        private String role;
+        private MemberStatus memberStatus;
+    }
 }

--- a/src/main/java/org/programmers/signalbuddy/domain/feedback/dto/FeedbackResponse.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/feedback/dto/FeedbackResponse.java
@@ -6,7 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.programmers.signalbuddy.domain.member.entity.enums.MemberStatus;
+import org.programmers.signalbuddy.domain.member.dto.MemberResponse;
 
 @Getter
 @Builder
@@ -22,15 +22,15 @@ public class FeedbackResponse {
     private LocalDateTime updatedAt;
     private MemberResponse member;
 
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    public static class MemberResponse {
-        private Long memberId;
-        private String nickname;
-        private String profileImageUrl;
-        private String role;
-        private MemberStatus memberStatus;
-    }
+//    @Getter
+//    @Builder
+//    @NoArgsConstructor
+//    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+//    public static class MemberResponse {
+//        private Long memberId;
+//        private String nickname;
+//        private String profileImageUrl;
+//        private String role;
+//        private MemberStatus memberStatus;
+//    }
 }

--- a/src/main/java/org/programmers/signalbuddy/domain/feedback/dto/FeedbackResponse.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/feedback/dto/FeedbackResponse.java
@@ -21,16 +21,4 @@ public class FeedbackResponse {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private MemberResponse member;
-
-//    @Getter
-//    @Builder
-//    @NoArgsConstructor
-//    @AllArgsConstructor(access = AccessLevel.PRIVATE)
-//    public static class MemberResponse {
-//        private Long memberId;
-//        private String nickname;
-//        private String profileImageUrl;
-//        private String role;
-//        private MemberStatus memberStatus;
-//    }
 }

--- a/src/main/java/org/programmers/signalbuddy/domain/feedback/repository/CustomFeedbackRepository.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/feedback/repository/CustomFeedbackRepository.java
@@ -1,0 +1,10 @@
+package org.programmers.signalbuddy.domain.feedback.repository;
+
+import org.programmers.signalbuddy.domain.feedback.dto.FeedbackResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomFeedbackRepository {
+
+    Page<FeedbackResponse> findAllByActiveMembers(Pageable pageable);
+}

--- a/src/main/java/org/programmers/signalbuddy/domain/feedback/repository/CustomFeedbackRepositoryImpl.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/feedback/repository/CustomFeedbackRepositoryImpl.java
@@ -1,0 +1,48 @@
+package org.programmers.signalbuddy.domain.feedback.repository;
+
+import static org.programmers.signalbuddy.domain.feedback.entity.QFeedback.feedback;
+import static org.programmers.signalbuddy.domain.member.entity.QMember.member;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.QBean;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.programmers.signalbuddy.domain.feedback.dto.FeedbackResponse;
+import org.programmers.signalbuddy.domain.member.entity.enums.MemberStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomFeedbackRepositoryImpl implements CustomFeedbackRepository {
+
+    private static final QBean<FeedbackResponse.MemberResponse> memberResponseDto = Projections.fields(
+        FeedbackResponse.MemberResponse.class, member.memberId, member.nickname,
+        member.profileImageUrl, member.role, member.memberStatus);
+
+    private static final QBean<FeedbackResponse> feedbackResponseDto = Projections.fields(
+        FeedbackResponse.class, feedback.feedbackId, feedback.subject, feedback.content,
+        feedback.likeCount, feedback.createdAt, feedback.updatedAt, memberResponseDto.as("member"));
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<FeedbackResponse> findAllByActiveMembers(Pageable pageable) {
+        List<FeedbackResponse> results = jpaQueryFactory.select(feedbackResponseDto).from(feedback)
+            .join(member).on(feedback.member.eq(member)).fetchJoin()
+            .where(member.memberStatus.eq(MemberStatus.ACTIVITY))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .orderBy(new OrderSpecifier<>(Order.DESC, feedback.updatedAt)).fetch();
+
+        Long count = jpaQueryFactory.select(feedback.count()).from(feedback)
+            .join(member).on(feedback.member.eq(member)).fetchJoin().fetchOne();
+
+        return new PageImpl<>(results, pageable, (count == null ? 0L : count));
+    }
+}

--- a/src/main/java/org/programmers/signalbuddy/domain/feedback/repository/CustomFeedbackRepositoryImpl.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/feedback/repository/CustomFeedbackRepositoryImpl.java
@@ -11,6 +11,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.programmers.signalbuddy.domain.feedback.dto.FeedbackResponse;
+import org.programmers.signalbuddy.domain.member.dto.MemberResponse;
 import org.programmers.signalbuddy.domain.member.entity.enums.MemberStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -21,8 +22,8 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class CustomFeedbackRepositoryImpl implements CustomFeedbackRepository {
 
-    private static final QBean<FeedbackResponse.MemberResponse> memberResponseDto = Projections.fields(
-        FeedbackResponse.MemberResponse.class, member.memberId, member.nickname,
+    private static final QBean<MemberResponse> memberResponseDto = Projections.fields(
+        MemberResponse.class, member.memberId, member.email, member.nickname,
         member.profileImageUrl, member.role, member.memberStatus);
 
     private static final QBean<FeedbackResponse> feedbackResponseDto = Projections.fields(
@@ -41,7 +42,8 @@ public class CustomFeedbackRepositoryImpl implements CustomFeedbackRepository {
             .orderBy(new OrderSpecifier<>(Order.DESC, feedback.updatedAt)).fetch();
 
         Long count = jpaQueryFactory.select(feedback.count()).from(feedback)
-            .join(member).on(feedback.member.eq(member)).fetchJoin().fetchOne();
+            .join(member).on(feedback.member.eq(member)).fetchJoin()
+            .where(member.memberStatus.eq(MemberStatus.ACTIVITY)).fetchOne();
 
         return new PageImpl<>(results, pageable, (count == null ? 0L : count));
     }

--- a/src/main/java/org/programmers/signalbuddy/domain/feedback/repository/FeedbackRepository.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/feedback/repository/FeedbackRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
+public interface FeedbackRepository extends JpaRepository<Feedback, Long>,
+    CustomFeedbackRepository {
 
 }

--- a/src/main/java/org/programmers/signalbuddy/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/feedback/service/FeedbackService.java
@@ -10,8 +10,11 @@ import org.programmers.signalbuddy.domain.feedback.repository.FeedbackRepository
 import org.programmers.signalbuddy.domain.member.entity.Member;
 import org.programmers.signalbuddy.domain.member.exception.MemberErrorCode;
 import org.programmers.signalbuddy.domain.member.repository.MemberRepository;
+import org.programmers.signalbuddy.global.dto.PageResponse;
 import org.programmers.signalbuddy.global.exception.BusinessException;
 import org.springframework.boot.autoconfigure.security.SecurityProperties.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +25,11 @@ public class FeedbackService {
 
     private final FeedbackRepository feedbackRepository;
     private final MemberRepository memberRepository;
+
+    public PageResponse<FeedbackResponse> searchFeedbackList(Pageable pageable) {
+        Page<FeedbackResponse> responsePage = feedbackRepository.findAllByActiveMembers(pageable);
+        return new PageResponse<>(responsePage);
+    }
 
     // TODO: 인자값에 User 객체는 나중에 변경해야 함!
     @Transactional

--- a/src/main/java/org/programmers/signalbuddy/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/feedback/service/FeedbackService.java
@@ -31,6 +31,12 @@ public class FeedbackService {
         return new PageResponse<>(responsePage);
     }
 
+    public FeedbackResponse searchFeedbackDetail(Long feedbackId) {
+        Feedback feedback = feedbackRepository.findById(feedbackId)
+            .orElseThrow(() -> new BusinessException(FeedbackErrorCode.NOT_FOUND_FEEDBACK));
+        return FeedbackMapper.INSTANCE.toResponse(feedback);
+    }
+
     // TODO: 인자값에 User 객체는 나중에 변경해야 함!
     @Transactional
     public FeedbackResponse writeFeedback(FeedbackWriteRequest request, User user) {

--- a/src/main/java/org/programmers/signalbuddy/domain/member/dto/MemberResponse.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/member/dto/MemberResponse.java
@@ -12,7 +12,7 @@ import org.programmers.signalbuddy.domain.member.entity.enums.MemberStatus;
 
 @Getter
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @ToString
 @EqualsAndHashCode

--- a/src/main/java/org/programmers/signalbuddy/global/dto/PageResponse.java
+++ b/src/main/java/org/programmers/signalbuddy/global/dto/PageResponse.java
@@ -1,0 +1,28 @@
+package org.programmers.signalbuddy.global.dto;
+
+import java.util.List;
+import javax.lang.model.util.Elements;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+public class PageResponse<T> {
+
+    private final long totalElements;
+    private final long totalPages;
+    private final long currentPageNumber;
+    private final long pageSize;
+    private final boolean hasNext;
+    private final boolean hasPrevious;
+    private final List<T> searchResults;
+
+    public PageResponse(Page<T> page) {
+        this.totalElements = page.getTotalElements();
+        this.totalPages = page.getTotalPages();
+        this.currentPageNumber = page.getNumber();
+        this.pageSize = page.getSize();
+        this.hasNext = page.hasNext();
+        this.hasPrevious = page.hasPrevious();
+        this.searchResults = page.getContent();
+    }
+}

--- a/src/test/java/org/programmers/signalbuddy/domain/feedback/repository/FeedbackRepositoryTest.java
+++ b/src/test/java/org/programmers/signalbuddy/domain/feedback/repository/FeedbackRepositoryTest.java
@@ -1,0 +1,66 @@
+package org.programmers.signalbuddy.domain.feedback.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.programmers.signalbuddy.domain.feedback.dto.FeedbackResponse;
+import org.programmers.signalbuddy.domain.feedback.dto.FeedbackWriteRequest;
+import org.programmers.signalbuddy.domain.feedback.entity.Feedback;
+import org.programmers.signalbuddy.domain.member.entity.Member;
+import org.programmers.signalbuddy.domain.member.entity.enums.MemberStatus;
+import org.programmers.signalbuddy.domain.member.repository.MemberRepository;
+import org.programmers.signalbuddy.global.support.RepositoryTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+class FeedbackRepositoryTest extends RepositoryTest {
+
+    @Autowired
+    private FeedbackRepository feedbackRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member member;
+
+    @BeforeEach
+    void setup() {
+        member = Member.builder().email("test@test.com").password("123456").role("USER")
+            .nickname("tester").memberStatus(MemberStatus.ACTIVITY)
+            .profileImageUrl("https://test-image.com/test-123131").build();
+        member = memberRepository.save(member);
+
+        List<Feedback> feedbackList = new ArrayList<>();
+        for (int i = 0; i < 123; i++) {
+            String subject = "test subject";
+            String content = "test content";
+            FeedbackWriteRequest request = new FeedbackWriteRequest(subject, content);
+            feedbackList.add(Feedback.create(request, member));
+        }
+        feedbackRepository.saveAll(feedbackList);
+    }
+
+    @DisplayName("탈퇴하지 않은 유저들의 피드백 목록 가져오기")
+    @Test
+    void findAllByActiveMembers() {
+        // when
+        Pageable pageable = PageRequest.of(3, 10);
+        Page<FeedbackResponse> actual = feedbackRepository.findAllByActiveMembers(pageable);
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual.getTotalElements()).isEqualTo(123);
+            softAssertions.assertThat(actual.getTotalPages()).isEqualTo(13);
+            softAssertions.assertThat(actual.getNumber()).isEqualTo(3);
+            softAssertions.assertThat(actual.getContent().size()).isEqualTo(10);
+            softAssertions.assertThat(actual.getContent().get(3).getFeedbackId()).isNotNull();
+            softAssertions.assertThat(actual.getContent().get(3).getMember().getMemberId())
+                .isEqualTo(member.getMemberId());
+        });
+    }
+}

--- a/src/test/java/org/programmers/signalbuddy/domain/feedback/service/FeedbackServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddy/domain/feedback/service/FeedbackServiceTest.java
@@ -117,7 +117,7 @@ class FeedbackServiceTest extends ServiceTest {
         FeedbackWriteRequest request = new FeedbackWriteRequest(updatedSubject, updatedContent);
         // TODO: User 객체는 나중에 변경해야 함!
         User user = new User();
-        user.setName("10");
+        user.setName("99999");
 
         // when & then
         assertThatThrownBy(() -> {
@@ -149,7 +149,7 @@ class FeedbackServiceTest extends ServiceTest {
         Long feedbackId = feedback.getFeedbackId();
         // TODO: User 객체는 나중에 변경해야 함!
         User user = new User();
-        user.setName("10");
+        user.setName("99999");
 
         // when & then
         assertThatThrownBy(() -> {
@@ -158,7 +158,7 @@ class FeedbackServiceTest extends ServiceTest {
             .hasMessage(FeedbackErrorCode.FEEDBACK_MODIFIER_NOT_AUTHORIZED.getMessage());
     }
 
-    @DisplayName("피드백 상세 조회")
+    @DisplayName("피드백 상세 조회 성공")
     @Test
     void searchFeedbackDetail() {
         // given

--- a/src/test/java/org/programmers/signalbuddy/domain/feedback/service/FeedbackServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddy/domain/feedback/service/FeedbackServiceTest.java
@@ -157,4 +157,24 @@ class FeedbackServiceTest extends ServiceTest {
         }).isExactlyInstanceOf(BusinessException.class)
             .hasMessage(FeedbackErrorCode.FEEDBACK_MODIFIER_NOT_AUTHORIZED.getMessage());
     }
+
+    @DisplayName("피드백 상세 조회")
+    @Test
+    void searchFeedbackDetail() {
+        // given
+        Long feedbackId = feedback.getFeedbackId();
+
+        // when
+        FeedbackResponse response = feedbackService.searchFeedbackDetail(feedbackId);
+
+        // then
+        Optional<Feedback> actual = feedbackRepository.findById(feedbackId);
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual.get().getFeedbackId()).isEqualTo(feedbackId);
+            softAssertions.assertThat(actual.get().getSubject()).isEqualTo(response.getSubject());
+            softAssertions.assertThat(actual.get().getContent()).isEqualTo(response.getContent());
+            softAssertions.assertThat(actual.get().getMember().getMemberId())
+                .isEqualTo(feedback.getMember().getMemberId());
+        });
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

> #22, #24 


## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 `ex) [feat] ㅇㅇ 기능 추가`
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료
- [x] 🏗️ 빌드 성공
- [x] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> 피드백 목록을 페이징하여 가져옴, 피드백 상세 조회 기능


## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->



## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> 처음에는 피드백 상세 조회할 때, 댓글 목록도 같이 가져오려고 했지만, Join을 최소 3번을 해야 돼서 각각 따로 API를 만들려고 합니다.

