### PR TITLE
[Feature] 교차로 데이터 가져와서 db에 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     // Web
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     // Lombok
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/programmers/signalbuddy/domain/crossroad/controller/CrossroadController.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/crossroad/controller/CrossroadController.java
@@ -1,5 +1,27 @@
 package org.programmers.signalbuddy.domain.crossroad.controller;
 
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.programmers.signalbuddy.domain.crossroad.service.CrossroadService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequestMapping("/api/crossroads")
+@RequiredArgsConstructor
 public class CrossroadController {
 
+    private final CrossroadService crossroadService;
+
+    @PostMapping("/save")
+    public ResponseEntity<Void> saveCrossroadDates(@Min(1) @RequestParam("page") int page,
+        @Min(10) @RequestParam("size") int pageSize) {
+        crossroadService.saveCrossroadDates(page, pageSize);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/org/programmers/signalbuddy/domain/crossroad/dto/CrossroadApiResponse.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/crossroad/dto/CrossroadApiResponse.java
@@ -1,0 +1,34 @@
+package org.programmers.signalbuddy.domain.crossroad.dto;
+
+import static org.programmers.signalbuddy.domain.crossroad.service.PointUtil.toPoint;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.locationtech.jts.geom.Point;
+
+@Getter
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CrossroadApiResponse {
+
+    @JsonProperty("itstId")
+    private String crossroadApiId;
+
+    @JsonProperty("itstNm")
+    private String name;
+
+    @JsonProperty("mapCtptIntLat")
+    private Double lat; // 위도
+
+    @JsonProperty("mapCtptIntLot")
+    private Double lng; // 경도
+
+    public Point getPoint() {
+        return toPoint(this.lat, this.lng);
+    }
+}

--- a/src/main/java/org/programmers/signalbuddy/domain/crossroad/entity/Crossroad.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/crossroad/entity/Crossroad.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.locationtech.jts.geom.Point;
 import org.programmers.signalbuddy.domain.basetime.BaseTimeEntity;
+import org.programmers.signalbuddy.domain.crossroad.dto.CrossroadApiResponse;
 
 @Entity(name = "crossroads")
 @Getter
@@ -34,4 +35,10 @@ public class Crossroad extends BaseTimeEntity {
 
     @Column(nullable = false)
     private Point coordinate;
+
+    public Crossroad(CrossroadApiResponse response) {
+        this.crossroadApiId = response.getCrossroadApiId();
+        this.name = response.getName();
+        this.coordinate = response.getPoint();
+    }
 }

--- a/src/main/java/org/programmers/signalbuddy/domain/crossroad/exception/CrossroadErrorCode.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/crossroad/exception/CrossroadErrorCode.java
@@ -1,0 +1,19 @@
+package org.programmers.signalbuddy.domain.crossroad.exception;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.programmers.signalbuddy.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum CrossroadErrorCode implements ErrorCode {
+
+    CROSSROAD_API_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 30000, "교차로 API 요청이 실패했습니다."),
+    ALREADY_EXIST_CROSSROAD(HttpStatus.CONFLICT, 30001, "이미 존재하는 교차로입니다.");
+
+    private HttpStatus httpStatus;
+    private int code;
+    private String message;
+}

--- a/src/main/java/org/programmers/signalbuddy/domain/crossroad/service/CrossroadProvider.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/crossroad/service/CrossroadProvider.java
@@ -1,0 +1,42 @@
+package org.programmers.signalbuddy.domain.crossroad.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.programmers.signalbuddy.domain.crossroad.dto.CrossroadApiResponse;
+import org.programmers.signalbuddy.domain.crossroad.exception.CrossroadErrorCode;
+import org.programmers.signalbuddy.global.exception.BusinessException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CrossroadProvider {
+
+    @Value("${t-data-api.api-key}")
+    private String API_KEY;
+    @Value("${t-data-api.crossroad-api}")
+    private String CROSSROAD_API_URL;
+
+    private final WebClient webClient;
+
+    public List<CrossroadApiResponse> requestCrossroadApi(int page, int pageSize) {
+        return webClient.get()
+            .uri(CROSSROAD_API_URL,
+                uriBuilder -> uriBuilder
+                    .queryParam("apiKey", API_KEY)
+                    .queryParam("pageNo", page)
+                    .queryParam("numOfRows", pageSize)
+                    .build())
+            .retrieve()
+            .bodyToMono(new ParameterizedTypeReference<List<CrossroadApiResponse>>() {})
+            .onErrorMap(e -> {
+                log.error("{}\n{}", e.getMessage(), e.getCause());
+                throw new BusinessException(CrossroadErrorCode.CROSSROAD_API_REQUEST_FAILED);
+            })
+            .block();
+    }
+}

--- a/src/main/java/org/programmers/signalbuddy/domain/crossroad/service/CrossroadService.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/crossroad/service/CrossroadService.java
@@ -1,13 +1,41 @@
 package org.programmers.signalbuddy.domain.crossroad.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.programmers.signalbuddy.domain.crossroad.dto.CrossroadApiResponse;
+import org.programmers.signalbuddy.domain.crossroad.entity.Crossroad;
+import org.programmers.signalbuddy.domain.crossroad.exception.CrossroadErrorCode;
 import org.programmers.signalbuddy.domain.crossroad.repository.CrossroadRepository;
+import org.programmers.signalbuddy.global.exception.BusinessException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CrossroadService {
 
     private final CrossroadRepository crossroadRepository;
+    private final CrossroadProvider crossroadProvider;
 
+    // TODO: 시간 남으면 Spring Batch로 동작시키기
+    @Transactional
+    public void saveCrossroadDates(int page, int pageSize) {
+        List<CrossroadApiResponse> responseList = crossroadProvider.requestCrossroadApi(page, pageSize);
+
+        List<Crossroad> entityList = new ArrayList<>();
+        for (CrossroadApiResponse response : responseList) {
+            if (response.getLng() != null && response.getLat() != null) {
+                entityList.add(new Crossroad(response));
+            }
+        }
+
+        try {
+            crossroadRepository.saveAll(entityList);
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(CrossroadErrorCode.ALREADY_EXIST_CROSSROAD);
+        }
+    }
 }

--- a/src/main/java/org/programmers/signalbuddy/domain/crossroad/service/PointUtil.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/crossroad/service/PointUtil.java
@@ -1,0 +1,20 @@
+package org.programmers.signalbuddy.domain.crossroad.service;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+
+public final class PointUtil {
+
+    private static final GeometryFactory geometryFactory = new GeometryFactory();
+
+    /**
+     * Double 형 위도 경도 값을 Point 객체로 만듦
+     * @param lat 위도
+     * @param lng 경도
+     * @return DB에 저장시킬 수 있는 Point 타입 (x: 경도, y: 위도)
+     */
+    public static Point toPoint(Double lat, Double lng) {
+        return geometryFactory.createPoint(new Coordinate(lng, lat));
+    }
+}

--- a/src/main/java/org/programmers/signalbuddy/global/config/WebClientConfig.java
+++ b/src/main/java/org/programmers/signalbuddy/global/config/WebClientConfig.java
@@ -1,0 +1,41 @@
+package org.programmers.signalbuddy.global.config;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebClientConfig {
+
+    @Value("${t-data-api.base-url}")
+    private String BASE_URL;
+
+    private final int processors = Runtime.getRuntime().availableProcessors();    // PC의 Processor 개수
+    private final HttpClient httpClient = HttpClient.create(
+            ConnectionProvider.builder("ApiConnections")
+                .maxConnections(processors * 2)
+                .pendingAcquireTimeout(Duration.ofMillis(0))    // 커넥션 풀에서 커넥션을 얻기 위해 기다리는 최대 시간
+                .pendingAcquireMaxCount(-1) // 커넥션 풀에서 커넥션을 가져오는 시도 횟수 (-1: no limit)
+                .maxIdleTime(Duration.ofMillis(1000L))  // 최대 유휴 시간 1초로 설정
+                .evictInBackground(Duration.ofMillis(1000L)) // 1초마다 유휴 Connections 확인하고 제거
+                .build()).responseTimeout(Duration.ofSeconds(30));    // 응답 초과 시간 30초로 설정
+
+    @Bean
+    public WebClient seoulApiWebClient() {
+
+        return WebClient.builder()
+            .baseUrl(BASE_URL)
+            .clientConnector(new ReactorClientHttpConnector(httpClient))
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .build();
+    }
+}

--- a/src/main/java/org/programmers/signalbuddy/global/exception/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/programmers/signalbuddy/global/exception/advice/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package org.programmers.signalbuddy.global.exception.advice;
 
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.programmers.signalbuddy.global.exception.BusinessException;
 import org.programmers.signalbuddy.global.exception.ErrorCode;
@@ -28,6 +29,15 @@ public class GlobalExceptionHandler {
         logError(e);
         int code = GlobalErrorCode.BAD_REQUEST.getCode();
         String message = e.getBindingResult().getFieldErrors().get(0).getDefaultMessage();
+        ErrorResponse errorResponse = new ErrorResponse(code, message);
+        return ResponseEntity.badRequest().body(errorResponse);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleValidException(ConstraintViolationException e) {
+        logError(e);
+        int code = GlobalErrorCode.BAD_REQUEST.getCode();
+        String message = e.getMessage();
         ErrorResponse errorResponse = new ErrorResponse(code, message);
         return ResponseEntity.badRequest().body(errorResponse);
     }

--- a/src/test/java/org/programmers/signalbuddy/domain/crossroad/service/CrossroadServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddy/domain/crossroad/service/CrossroadServiceTest.java
@@ -1,0 +1,62 @@
+package org.programmers.signalbuddy.domain.crossroad.service;
+
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.programmers.signalbuddy.domain.crossroad.dto.CrossroadApiResponse;
+import org.programmers.signalbuddy.domain.crossroad.entity.Crossroad;
+import org.programmers.signalbuddy.domain.crossroad.repository.CrossroadRepository;
+import org.programmers.signalbuddy.global.support.ServiceTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+class CrossroadServiceTest extends ServiceTest {
+
+    @Autowired
+    private CrossroadService crossroadService;
+
+    @Autowired
+    private CrossroadRepository crossroadRepository;
+
+    @MockitoBean
+    private CrossroadProvider crossroadProvider;
+
+    @DisplayName("Open API를 요청할 때, 페이지 수와 사이즈를 지정하고 다음 해당 데이터 저장")
+    @Test
+    void saveCrossroadDates() {
+        // given
+        List<CrossroadApiResponse> expectedList = new ArrayList<>();
+        for (int i = 1; i <= 10; i++) {
+            expectedList.add(
+                CrossroadApiResponse.builder()
+                    .crossroadApiId("aaaaa" + i)
+                    .name("aaaa" + i)
+                    .lat(i * 5.0)
+                    .lng(i * 7.0)
+                    .build());
+        }
+
+        // when
+        when(crossroadProvider.requestCrossroadApi(0, 10)).thenReturn(expectedList);
+        crossroadService.saveCrossroadDates(0, 10);
+
+        // then
+        List<Crossroad> actual = crossroadRepository.findAll();
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual.size()).isEqualTo(expectedList.size());
+            softAssertions.assertThat(actual.get(5).getCrossroadApiId()).isEqualTo(expectedList.get(5).getCrossroadApiId());
+            softAssertions.assertThat(actual.get(5).getName()).isEqualTo(expectedList.get(5).getName());
+            softAssertions.assertThat(actual.get(5).getCoordinate().getX()).isEqualTo(expectedList.get(5).getLng());
+            softAssertions.assertThat(actual.get(5).getCoordinate().getY()).isEqualTo(expectedList.get(5).getLat());
+        });
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

> #47 


## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 `ex) [feat] ㅇㅇ 기능 추가`
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료
- [x] 🏗️ 빌드 성공
- [x] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> T-Data API를 통해서 교차로 데이터를 가져온 다음 해당 데이터를 저장한다.


## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->

![image](https://github.com/user-attachments/assets/a55bb797-6a94-41fd-a470-a3701fd98274)

## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> coordinate의 경우 객체라서 해시값이 저장되어 있고, 테스트 코드를 통해서 좌표값이 잘 저장된 것을 확인할 수 있었습니다.

