### PR TITLE
[fix] 좋아요 개수 정합성 문제

### DIFF
--- a/src/main/java/org/programmers/signalbuddy/domain/like/batch/LikeJobConfig.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/like/batch/LikeJobConfig.java
@@ -1,0 +1,62 @@
+package org.programmers.signalbuddy.domain.like.batch;
+
+import lombok.RequiredArgsConstructor;
+import org.programmers.signalbuddy.domain.feedback.repository.FeedbackRepository;
+import org.programmers.signalbuddy.domain.like.dto.LikeUpdateRequest;
+import org.programmers.signalbuddy.domain.like.repository.LikeJdbcRepository;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class LikeJobConfig {
+
+    private final StringRedisTemplate redisTemplate;
+    private final FeedbackRepository feedbackRepository;
+    private final LikeJdbcRepository likeJdbcRepository;
+
+    @Bean
+    public Job likeRequestJob(JobRepository jobRepository,
+        PlatformTransactionManager transactionManager) {
+
+        return new JobBuilder("likeRequestJob", jobRepository)
+            .incrementer(new RunIdIncrementer())    // 동일한 파라미터를 다시 실행
+            .start(updateLikeBatch(jobRepository, transactionManager))
+            .build();
+    }
+
+    @Bean
+    @JobScope
+    public Step updateLikeBatch(JobRepository jobRepository,
+        PlatformTransactionManager transactionManager) {
+
+        return new StepBuilder("updateLikeBatch", jobRepository)
+            .<LikeUpdateRequest, LikeUpdateRequest>chunk(100, transactionManager)
+            .reader(requestLikeReader())
+            .writer(requestLikeWriter())
+            .allowStartIfComplete(true) // COMPLETED 되어도 재실행에 포함시키기
+            .build();
+    }
+
+    @Bean
+    @StepScope
+    public RequestLikeReader requestLikeReader() {
+        return new RequestLikeReader(redisTemplate);
+    }
+
+    @Bean
+    @StepScope
+    public RequestLikeWriter requestLikeWriter() {
+        return new RequestLikeWriter(feedbackRepository, likeJdbcRepository, redisTemplate);
+    }
+}

--- a/src/main/java/org/programmers/signalbuddy/domain/like/batch/LikeJobScheduler.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/like/batch/LikeJobScheduler.java
@@ -1,0 +1,24 @@
+package org.programmers.signalbuddy.domain.like.batch;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Configuration
+@RequiredArgsConstructor
+public class LikeJobScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job likeRequestJob;
+
+    @Scheduled(cron = "${schedule.like-job.cron}")
+    public void runJob() throws Exception {
+        JobParameters params = new JobParametersBuilder()
+            .toJobParameters();
+        jobLauncher.run(likeRequestJob, params);
+    }
+}

--- a/src/main/java/org/programmers/signalbuddy/domain/like/batch/RequestLikeReader.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/like/batch/RequestLikeReader.java
@@ -1,0 +1,51 @@
+package org.programmers.signalbuddy.domain.like.batch;
+
+import static org.programmers.signalbuddy.domain.like.service.LikeService.getLikeKeyPrefix;
+
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import org.programmers.signalbuddy.domain.like.dto.LikeUpdateRequest;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamReader;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RequestLikeReader implements ItemStreamReader<LikeUpdateRequest> {
+
+    private final StringRedisTemplate redisTemplate;
+    private Cursor<byte[]> cursor;
+
+    @Override
+    public void open(ExecutionContext executionContext) {
+        ScanOptions scanOptions = ScanOptions.scanOptions()
+            .match(getLikeKeyPrefix() + "*")
+            .build();
+
+        cursor = redisTemplate.executeWithStickyConnection(
+            connection -> connection.scan(scanOptions));
+    }
+
+    @Override
+    public LikeUpdateRequest read() throws Exception {
+        if (cursor != null && cursor.hasNext()) {
+            String key = new String(cursor.next(), StandardCharsets.UTF_8);
+            String[] keyInfo = key.split(":");
+
+            Long feedbackId = Long.parseLong(keyInfo[1]);
+            Long memberId = Long.parseLong(keyInfo[2]);
+            String likeRequestType = redisTemplate.opsForValue().get(key);
+
+            return LikeUpdateRequest.builder()
+                .feedbackId(feedbackId)
+                .memberId(memberId)
+                .likeRequestType(likeRequestType)
+                .build();
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/programmers/signalbuddy/domain/like/batch/RequestLikeWriter.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/like/batch/RequestLikeWriter.java
@@ -1,0 +1,61 @@
+package org.programmers.signalbuddy.domain.like.batch;
+
+import static org.programmers.signalbuddy.domain.like.service.LikeService.generateKey;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.programmers.signalbuddy.domain.feedback.entity.Feedback;
+import org.programmers.signalbuddy.domain.feedback.repository.FeedbackRepository;
+import org.programmers.signalbuddy.domain.like.dto.LikeRequestType;
+import org.programmers.signalbuddy.domain.like.dto.LikeUpdateRequest;
+import org.programmers.signalbuddy.domain.like.repository.LikeJdbcRepository;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+public class RequestLikeWriter implements ItemWriter<LikeUpdateRequest> {
+
+    private final FeedbackRepository feedbackRepository;
+    private final LikeJdbcRepository likeJdbcRepository;
+    private final StringRedisTemplate redisTemplate;
+
+    @Transactional
+    @Override
+    public void write(Chunk<? extends LikeUpdateRequest> chunk) {
+        log.info("like job chunk size : {}", chunk.size());
+
+        List<LikeUpdateRequest> savedLikeList = new ArrayList<>();   // 저장할 좋아요 데이터
+        List<LikeUpdateRequest> deletedLikeList = new ArrayList<>(); // 삭제할 좋아요 데이터
+        List<String> likeKeyList = new ArrayList<>(); // Redis에 저장된 좋아요 데이터의 키
+
+        // 요청된 좋아요 개수 및 좋아요 데이터 반영
+        for (LikeUpdateRequest request : chunk.getItems()) {
+
+            Feedback feedback = feedbackRepository.findById(request.getFeedbackId()).orElse(null);
+            if (feedback == null) {
+                redisTemplate.delete(generateKey(request));
+                continue;
+            }
+
+            if (LikeRequestType.ADD.equals(request.getLikeRequestType())) {
+                savedLikeList.add(request);
+                feedback.increaseLike();
+
+            } else if (LikeRequestType.CANCEL.equals(request.getLikeRequestType())) {
+                deletedLikeList.add(request);
+                feedback.decreaseLike();
+            }
+
+            likeKeyList.add(generateKey(request));
+        }
+
+        likeJdbcRepository.saveAllInBatch(savedLikeList);
+        likeJdbcRepository.deleteAllByLikeRequestsInBatch(deletedLikeList);
+        redisTemplate.delete(likeKeyList);
+    }
+}

--- a/src/main/java/org/programmers/signalbuddy/domain/like/controller/LikeController.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/like/controller/LikeController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "좋아요 API")
+@Tag(name = "Like API")
 @RestController
 @RequestMapping("/api/feedbacks")
 @RequiredArgsConstructor

--- a/src/main/java/org/programmers/signalbuddy/domain/like/dto/LikeRequestType.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/like/dto/LikeRequestType.java
@@ -1,0 +1,14 @@
+package org.programmers.signalbuddy.domain.like.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum LikeRequestType {
+
+    ADD("추가 요청"), CANCEL("취소 요청");
+
+    private final String requestType;
+}

--- a/src/main/java/org/programmers/signalbuddy/domain/like/dto/LikeUpdateRequest.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/like/dto/LikeUpdateRequest.java
@@ -1,0 +1,33 @@
+package org.programmers.signalbuddy.domain.like.dto;
+
+import java.util.Objects;
+import lombok.Builder;
+import lombok.Getter;
+import org.programmers.signalbuddy.domain.like.exception.LikeErrorCode;
+import org.programmers.signalbuddy.global.exception.BusinessException;
+
+@Getter
+public class LikeUpdateRequest {
+
+    private Long feedbackId;
+    private Long memberId;
+    private LikeRequestType likeRequestType;
+
+    @Builder
+    private LikeUpdateRequest(Long feedbackId, Long memberId, String likeRequestType) {
+        this.feedbackId = Objects.requireNonNull(feedbackId);
+        this.memberId = Objects.requireNonNull(memberId);
+        this.likeRequestType = toEnum(Objects.requireNonNull(likeRequestType));
+    }
+
+    private LikeRequestType toEnum(String likeRequestType) {
+        if (likeRequestType.equals(LikeRequestType.ADD.name())) {
+            return LikeRequestType.ADD;
+        }
+        if (likeRequestType.equals(LikeRequestType.CANCEL.name())) {
+            return LikeRequestType.CANCEL;
+        }
+
+        throw new BusinessException(LikeErrorCode.Illegal_REQUEST_TYPE);
+    }
+}

--- a/src/main/java/org/programmers/signalbuddy/domain/like/entity/Like.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/like/entity/Like.java
@@ -10,13 +10,14 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.programmers.signalbuddy.domain.basetime.BaseTimeEntity;
 import org.programmers.signalbuddy.domain.feedback.entity.Feedback;
 import org.programmers.signalbuddy.domain.member.entity.Member;
 
 @Entity(name = "likes")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Like {
+public class Like extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/programmers/signalbuddy/domain/like/exception/LikeErrorCode.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/like/exception/LikeErrorCode.java
@@ -1,0 +1,20 @@
+package org.programmers.signalbuddy.domain.like.exception;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.programmers.signalbuddy.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum LikeErrorCode implements ErrorCode {
+
+    ALREADY_ADDED_LIKE(HttpStatus.CONFLICT, 50000, "이미 좋아요 추가되었습니다."),
+    NOT_FOUND_LIKE(HttpStatus.NOT_FOUND, 50001, "좋아요 데이터가 존재하지 않습니다."),
+    Illegal_REQUEST_TYPE(HttpStatus.INTERNAL_SERVER_ERROR, 50002, "잘못된 좋아요 요청 상태입니다.");
+
+    private HttpStatus httpStatus;
+    private int code;
+    private String message;
+}

--- a/src/main/java/org/programmers/signalbuddy/domain/like/repository/LikeJdbcRepository.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/like/repository/LikeJdbcRepository.java
@@ -1,0 +1,58 @@
+package org.programmers.signalbuddy.domain.like.repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.programmers.signalbuddy.domain.like.dto.LikeUpdateRequest;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class LikeJdbcRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public void saveAllInBatch(List<LikeUpdateRequest> likeUpdateRequests) {
+        String sql = "INSERT INTO likes (member_id, feedback_id, created_at, updated_at) "
+            + "VALUES (?, ?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                LocalDateTime now = LocalDateTime.now();
+                LikeUpdateRequest request = likeUpdateRequests.get(i);
+                ps.setLong(1, request.getMemberId());
+                ps.setLong(2, request.getFeedbackId());
+                ps.setObject(3, now);
+                ps.setObject(4, now);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return likeUpdateRequests.size();
+            }
+        });
+    }
+
+    public void deleteAllByLikeRequestsInBatch(List<LikeUpdateRequest> likeUpdateRequests) {
+        String sql = "DELETE FROM likes WHERE member_id = ? AND feedback_id = ?";
+
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                LikeUpdateRequest request = likeUpdateRequests.get(i);
+                ps.setLong(1, request.getMemberId());
+                ps.setLong(2, request.getFeedbackId());
+            }
+
+            @Override
+            public int getBatchSize() {
+                return likeUpdateRequests.size();
+            }
+        });
+    }
+}

--- a/src/main/java/org/programmers/signalbuddy/domain/like/repository/LikeRepository.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/like/repository/LikeRepository.java
@@ -1,8 +1,6 @@
 package org.programmers.signalbuddy.domain.like.repository;
 
-import org.programmers.signalbuddy.domain.feedback.entity.Feedback;
 import org.programmers.signalbuddy.domain.like.entity.Like;
-import org.programmers.signalbuddy.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,9 +9,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
-    void deleteByMemberAndFeedback(Member member, Feedback feedback);
-
-    @Query("SELECT CASE  WHEN count(*)> 0 THEN true ELSE false END "
+    @Query("SELECT CASE  WHEN count(*) > 0 THEN true ELSE false END "
         + "FROM likes l "
         + "WHERE l.member.memberId = :memberId AND l.feedback.feedbackId = :feedbackId")
     boolean existsByMemberAndFeedback(@Param("memberId") Long memberId,

--- a/src/main/java/org/programmers/signalbuddy/domain/like/service/LikeService.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/like/service/LikeService.java
@@ -1,14 +1,15 @@
 package org.programmers.signalbuddy.domain.like.service;
 
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
-import org.programmers.signalbuddy.domain.feedback.entity.Feedback;
-import org.programmers.signalbuddy.domain.feedback.repository.FeedbackRepository;
 import org.programmers.signalbuddy.domain.like.dto.LikeExistResponse;
-import org.programmers.signalbuddy.domain.like.entity.Like;
+import org.programmers.signalbuddy.domain.like.dto.LikeRequestType;
+import org.programmers.signalbuddy.domain.like.exception.LikeErrorCode;
 import org.programmers.signalbuddy.domain.like.repository.LikeRepository;
-import org.programmers.signalbuddy.domain.member.entity.Member;
-import org.programmers.signalbuddy.domain.member.repository.MemberRepository;
 import org.programmers.signalbuddy.global.dto.CustomUser2Member;
+import org.programmers.signalbuddy.global.exception.BusinessException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,16 +19,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class LikeService {
 
     private final LikeRepository likeRepository;
-    private final MemberRepository memberRepository;
-    private final FeedbackRepository feedbackRepository;
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String LIKE_KEY_PREFIX = "like:";
 
     @Transactional
     public void addLike(Long feedbackId, CustomUser2Member user) {
-        Feedback feedback = feedbackRepository.findByIdOrThrow(feedbackId);
-        Member member = memberRepository.findByIdOrThrow(user.getMemberId());
+        boolean isExisted = likeRepository.existsByMemberAndFeedback(user.getMemberId(), feedbackId);
+        if (isExisted) {
+            throw new BusinessException(LikeErrorCode.ALREADY_ADDED_LIKE);
+        }
 
-        likeRepository.save(Like.create(member, feedback));
-        feedback.increaseLike();
+        ValueOperations<String, String> operations = redisTemplate.opsForValue();
+        String key = generateKey(feedbackId, user.getMemberId());
+        operations.set(key, LikeRequestType.ADD.name(), 3L, TimeUnit.MINUTES);
     }
 
     public LikeExistResponse existsLike(Long feedbackId, CustomUser2Member user) {
@@ -37,10 +42,16 @@ public class LikeService {
 
     @Transactional
     public void deleteLike(Long feedbackId, CustomUser2Member user) {
-        Feedback feedback = feedbackRepository.findByIdOrThrow(feedbackId);
-        Member member = memberRepository.findByIdOrThrow(user.getMemberId());
+        ValueOperations<String, String> operations = redisTemplate.opsForValue();
+        String key = generateKey(feedbackId, user.getMemberId());
+        operations.set(key, LikeRequestType.CANCEL.name(), 3L, TimeUnit.MINUTES);
+    }
 
-        likeRepository.deleteByMemberAndFeedback(member, feedback);
-        feedback.decreaseLike();
+    String generateKey(Long feedbackId, Long memberId) {
+        return LIKE_KEY_PREFIX + feedbackId + ":" + memberId;
+    }
+
+    public static String getLikeKeyPrefix() {
+        return LIKE_KEY_PREFIX;
     }
 }

--- a/src/main/java/org/programmers/signalbuddy/global/config/RedisConfig.java
+++ b/src/main/java/org/programmers/signalbuddy/global/config/RedisConfig.java
@@ -3,17 +3,24 @@ package org.programmers.signalbuddy.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+@Profile("!test")
 @EnableRedisRepositories
 @EnableRedisHttpSession
 @Configuration
+@EnableTransactionManagement
 public class RedisConfig {
 
     @Value("${spring.data.redis.host}")
@@ -37,11 +44,25 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<Object, Object> redisTemplate() {
+    public RedisTemplate<Object, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<Object, Object> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.setEnableTransactionSupport(true);    // 트랜잭션 허용
+        redisTemplate.setDefaultSerializer(new GenericJackson2JsonRedisSerializer());
+
+        // Key Serializer: 문자열
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+
+        // Value Serializer: JSON 직렬화
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
         return redisTemplate;
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager() {
+        return new JpaTransactionManager();
     }
 }

--- a/src/test/java/org/programmers/signalbuddy/domain/like/batch/LikeJobConfigTest.java
+++ b/src/test/java/org/programmers/signalbuddy/domain/like/batch/LikeJobConfigTest.java
@@ -1,0 +1,114 @@
+package org.programmers.signalbuddy.domain.like.batch;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.programmers.signalbuddy.domain.feedback.dto.FeedbackWriteRequest;
+import org.programmers.signalbuddy.domain.feedback.entity.Feedback;
+import org.programmers.signalbuddy.domain.feedback.repository.FeedbackRepository;
+import org.programmers.signalbuddy.domain.like.service.LikeService;
+import org.programmers.signalbuddy.domain.member.entity.Member;
+import org.programmers.signalbuddy.domain.member.entity.enums.MemberRole;
+import org.programmers.signalbuddy.domain.member.entity.enums.MemberStatus;
+import org.programmers.signalbuddy.domain.member.repository.MemberRepository;
+import org.programmers.signalbuddy.global.db.RedisTestContainer;
+import org.programmers.signalbuddy.global.dto.CustomUser2Member;
+import org.programmers.signalbuddy.global.security.basic.CustomUserDetails;
+import org.programmers.signalbuddy.global.support.BatchTest;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class LikeJobConfigTest extends BatchTest implements RedisTestContainer {
+
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+
+    @Autowired
+    private Job likeRequestJob;
+
+    @Autowired
+    private LikeService likeService;
+
+    @Autowired
+    private FeedbackRepository feedbackRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private List<Member> savedMemberList;
+
+    @BeforeEach
+    void setup() {
+        List<Member> memberList = new ArrayList<>();
+        for (int i = 0; i < 550; i++) {
+            Member member = Member.builder()
+                .email("test@test.com")
+                .password("123456" + i)
+                .role(MemberRole.USER)
+                .nickname("tester")
+                .memberStatus(MemberStatus.ACTIVITY)
+                .profileImageUrl("https://test-image.com/test-123131")
+                .build();
+            memberList.add(member);
+        }
+        savedMemberList = memberRepository.saveAll(memberList);
+    }
+
+    @DisplayName("동시에 많은 좋아요 추가/취소 요청이 발생할 때, 좋아요 개수의 정합성 확인")
+    @Test
+    void likeRequestJob() throws Exception {
+        // given
+        int addLikeThreadCount = savedMemberList.size(); // 좋아요 추가 요청의 스레드 개수
+        ExecutorService executorService = Executors.newFixedThreadPool(addLikeThreadCount);    // 스레드 풀 생성
+        CountDownLatch latch = new CountDownLatch(addLikeThreadCount); // 스레드 대기 관리
+
+        String subject = "test subject";
+        String content = "test content";
+        FeedbackWriteRequest request = new FeedbackWriteRequest(subject, content);
+        Feedback savedFeedback = feedbackRepository.saveAndFlush(Feedback.create(request, savedMemberList.get(0)));
+
+        // when
+        // 좋아요 추가/취소 반반씩
+        for (int i = 0; i < addLikeThreadCount; i++) {
+            Member member = savedMemberList.get(i);
+            executorService.submit(() -> {
+                try {
+                    CustomUser2Member user = new CustomUser2Member(
+                        new CustomUserDetails(member.getMemberId(), "", "",
+                            "", "", MemberRole.USER, MemberStatus.ACTIVITY));
+
+                    likeService.deleteLike(savedFeedback.getFeedbackId(), user);    // 적용 X (해당 키 존재 X)
+                    likeService.addLike(savedFeedback.getFeedbackId(), user);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // 스레드가 다 끝날 때까지 기다리기
+        latch.await();
+        executorService.shutdown();
+
+        jobLauncherTestUtils.setJob(likeRequestJob);
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob();
+
+        // then
+        Feedback updatedFeedback = feedbackRepository.findById(savedFeedback.getFeedbackId()).get();
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+            softAssertions.assertThat(updatedFeedback.getLikeCount())
+                .isEqualTo(addLikeThreadCount);
+        });
+    }
+}

--- a/src/test/java/org/programmers/signalbuddy/domain/like/service/LikeServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddy/domain/like/service/LikeServiceTest.java
@@ -192,42 +192,4 @@ class LikeServiceTest extends ServiceTest implements RedisTestContainer {
         // then
         assertThat(actual.getStatus()).isFalse();
     }
-
-    @DisplayName("동시에 많은 좋아요 추가 요청이 발생할 때, 좋아요 개수의 정합성 확인")
-    @Test
-    void IsNotEqualLikeCount() throws InterruptedException {
-        // given
-        int threadCount = 1000; // 스레드 개수
-        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);    // 스레드 풀 생성
-        CountDownLatch latch = new CountDownLatch(threadCount); // 스레드 대기 관리
-
-        String subject = "test subject";
-        String content = "test content";
-        FeedbackWriteRequest request = new FeedbackWriteRequest(subject, content);
-        Feedback savedFeedback = feedbackRepository.saveAndFlush(Feedback.create(request, member));
-
-        // when
-        for (int i = 0; i < threadCount; i++) {
-            executorService.submit(() -> {
-                try {
-                    CustomUser2Member user = new CustomUser2Member(
-                        new CustomUserDetails(member.getMemberId(), "", "",
-                            "", "", MemberRole.USER, MemberStatus.ACTIVITY));
-                    likeService.addLike(savedFeedback.getFeedbackId(), user);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                } finally {
-                    latch.countDown();
-                }
-            });
-        }
-
-        // 스레드가 다 끝날 때까지 기다리기
-        latch.await();
-        executorService.shutdown();
-
-        // then
-        Feedback updatedFeedback = feedbackRepository.findById(savedFeedback.getFeedbackId()).get();
-        assertThat(updatedFeedback.getLikeCount()).isEqualTo(threadCount);
-    }
 }

--- a/src/test/java/org/programmers/signalbuddy/global/config/RedisConfig.java
+++ b/src/test/java/org/programmers/signalbuddy/global/config/RedisConfig.java
@@ -1,0 +1,31 @@
+package org.programmers.signalbuddy.global.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+
+@TestConfiguration
+@EnableRedisHttpSession
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<Object, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<Object, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.setDefaultSerializer(new GenericJackson2JsonRedisSerializer());
+
+        // Key Serializer: 문자열
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+
+        // Value Serializer: JSON 직렬화
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/test/java/org/programmers/signalbuddy/global/config/RedisConfig.java
+++ b/src/test/java/org/programmers/signalbuddy/global/config/RedisConfig.java
@@ -6,16 +6,21 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @TestConfiguration
 @EnableRedisHttpSession
+@EnableTransactionManagement
 public class RedisConfig {
 
     @Bean
     public RedisTemplate<Object, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<Object, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.setEnableTransactionSupport(true);    // 트랜잭션 허용
         redisTemplate.setDefaultSerializer(new GenericJackson2JsonRedisSerializer());
 
         // Key Serializer: 문자열
@@ -27,5 +32,10 @@ public class RedisConfig {
         redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
 
         return redisTemplate;
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager() {
+        return new JpaTransactionManager();
     }
 }

--- a/src/test/java/org/programmers/signalbuddy/global/config/RedisConfigTest.java
+++ b/src/test/java/org/programmers/signalbuddy/global/config/RedisConfigTest.java
@@ -6,14 +6,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.programmers.signalbuddy.global.db.RedisTestContainer;
-import org.programmers.signalbuddy.global.support.ServiceTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.context.ActiveProfiles;
 
-public class RedisConfigTest extends ServiceTest implements RedisTestContainer {
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+public class RedisConfigTest implements RedisTestContainer {
 
     private static final Logger log = LoggerFactory.getLogger(RedisConfigTest.class);
 

--- a/src/test/java/org/programmers/signalbuddy/global/config/RedisConfigTest.java
+++ b/src/test/java/org/programmers/signalbuddy/global/config/RedisConfigTest.java
@@ -1,4 +1,3 @@
-/*
 package org.programmers.signalbuddy.global.config;
 
 
@@ -6,18 +5,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.programmers.signalbuddy.global.db.RedisTestContainer;
+import org.programmers.signalbuddy.global.support.ServiceTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
-@SpringBootTest
-public class RedisConfigTest {
+public class RedisConfigTest extends ServiceTest implements RedisTestContainer {
+
     private static final Logger log = LoggerFactory.getLogger(RedisConfigTest.class);
+
     @Autowired
-    RedisTemplate<String, String> redisTemplate;
+    private StringRedisTemplate redisTemplate;
 
     @DisplayName("redis 작동 확인")
     @Test
@@ -36,4 +37,3 @@ public class RedisConfigTest {
         redisTemplate.delete(key);
     }
 }
-*/

--- a/src/test/java/org/programmers/signalbuddy/global/db/RedisTestContainer.java
+++ b/src/test/java/org/programmers/signalbuddy/global/db/RedisTestContainer.java
@@ -1,0 +1,29 @@
+package org.programmers.signalbuddy.global.db;
+
+import org.programmers.signalbuddy.global.config.RedisConfig;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+@Import(RedisConfig.class)
+public interface RedisTestContainer {
+
+    String REDIS_IMAGE = "redis:7.4.1-alpine";
+    int REDIS_PORT = 6379;
+
+    @Container
+    GenericContainer<?> REDIS_CONTAINER = new GenericContainer<>(DockerImageName.parse(REDIS_IMAGE))
+        .withExposedPorts(REDIS_PORT)
+        .withReuse(true);
+
+    @DynamicPropertySource
+    private static void registerRedisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", REDIS_CONTAINER::getHost);
+        registry.add("spring.data.redis.port", () -> REDIS_CONTAINER.getMappedPort(REDIS_PORT));
+    }
+}

--- a/src/test/java/org/programmers/signalbuddy/global/support/BatchTest.java
+++ b/src/test/java/org/programmers/signalbuddy/global/support/BatchTest.java
@@ -1,0 +1,8 @@
+package org.programmers.signalbuddy.global.support;
+
+import org.springframework.batch.test.context.SpringBatchTest;
+
+@SpringBatchTest
+public abstract class BatchTest extends ServiceTest{
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -31,3 +31,7 @@ logging:
     org.springframework.jdbc.core.StatementCreatorUtils: TRACE
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql: TRACE
+
+schedule:
+  like-job:
+    cron: "2 0 3 * * ?" # 매일 1시 2초마다


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

> #122 


## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 `ex) [feat] ㅇㅇ 기능 추가`
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료
- [x] 🏗️ 빌드 성공
- [x] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> Redis에 좋아요 요청 데이터를 저장하고 배치 작업을 통해 좋아요 개수의 정합성 문제를 해결했습니다.


## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->



## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> 테스트 코드를 통해서 정합성 문제를 확인했습니다.
> 좋아요 추가/취소 요청을 redis에 저장한 뒤 Spring Batch로 좋아요 데이터를 배치 작업했습니다.
> 배치 작업 주기는 5초마다로 설정했습니다.
> 테스트 코드를 작성해서 정합성을 확인하긴 했지만, 부족하다고 생각되어 나중에 성능 테스트하면서 다시 검증해야 할 것 같습니다.

