### PR TITLE
[feat] 스케줄러 분산 락 걸기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 
+    // Scheduling Lock
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:6.2.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:6.2.0'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/org/programmers/signalbuddy/domain/admin/batch/JobConfig.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/admin/batch/JobConfig.java
@@ -42,7 +42,9 @@ public class JobConfig {
     public Step deleteMemberStep(JobRepository jobRepository,
         PlatformTransactionManager transactionManager) {
         return new StepBuilder("deleteMemberStep", jobRepository).<Member, Member>chunk(chunkSize,
-            transactionManager).reader(customReader()).writer(deleteMemberWriter()).build();
+            transactionManager)
+            .allowStartIfComplete(true) // COMPLETED 되어도 재실행에 포함시키기
+            .reader(customReader()).writer(deleteMemberWriter()).build();
     }
 
 

--- a/src/main/java/org/programmers/signalbuddy/domain/admin/batch/Scheduler.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/admin/batch/Scheduler.java
@@ -1,16 +1,15 @@
 package org.programmers.signalbuddy.domain.admin.batch;
 
 import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 
 @Configuration
-@EnableScheduling
 @RequiredArgsConstructor
 public class Scheduler {
 
@@ -18,6 +17,10 @@ public class Scheduler {
     private final Job deleteMemberJob;
 
     @Scheduled(cron = "0 59 23 * * ?")
+    @SchedulerLock(
+        name = "DeleteMemberJobScheduler",
+        lockAtMostFor = "23h",
+        lockAtLeastFor = "23h")
     public void runJob() throws Exception {
 
         JobParameters params = new JobParametersBuilder()

--- a/src/main/java/org/programmers/signalbuddy/domain/like/batch/LikeJobScheduler.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/like/batch/LikeJobScheduler.java
@@ -1,6 +1,7 @@
 package org.programmers.signalbuddy.domain.like.batch;
 
 import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
@@ -16,6 +17,10 @@ public class LikeJobScheduler {
     private final Job likeRequestJob;
 
     @Scheduled(cron = "${schedule.like-job.cron}")
+    @SchedulerLock(
+        name = "LikeJobScheduler",
+        lockAtMostFor = "${schedule.like-job.lockAtMostFor}",
+        lockAtLeastFor = "${schedule.like-job.lockAtLeastFor}")
     public void runJob() throws Exception {
         JobParameters params = new JobParametersBuilder()
             .toJobParameters();

--- a/src/main/java/org/programmers/signalbuddy/global/config/SchedulerConfig.java
+++ b/src/main/java/org/programmers/signalbuddy/global/config/SchedulerConfig.java
@@ -1,0 +1,20 @@
+package org.programmers.signalbuddy.global.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "10m")
+public class SchedulerConfig {
+
+    @Bean
+    public LockProvider lockProvider(RedisConnectionFactory connectionFactory) {
+        return new RedisLockProvider(connectionFactory);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -35,3 +35,5 @@ logging:
 schedule:
   like-job:
     cron: "2 0 3 * * ?" # 매일 1시 2초마다
+    lockAtMostFor: 23h  # 오류 발생 시 락을 유지하는 시간 (작업의 실행 시간보다 길게 하는 게 좋음)
+    lockAtLeastFor: 23h # 락을 유지하는 최소 시간 (스케줄러 시간보다 짧게 지정하는 게 좋음)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #142 


## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 `ex) [feat] ㅇㅇ 기능 추가`
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료
- [x] 🏗️ 빌드 성공
- [x] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> 멀티 서버에서 스케줄러가 중복 실행되지 않게 스케줄러를 분산 락을 이용하여 처리하였다.


## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->

![분산락-1](https://github.com/user-attachments/assets/4c742d91-de29-4f99-9eaf-88714fc86278)

![분산락-2](https://github.com/user-attachments/assets/b34c837a-7541-42ec-91e0-5e671b52ae02)

각 사진의 로그는 서로 다른 컨테이너로 실행된 서버의 로그입니다.

첫 번째 사진의 서버에서 먼저 스케줄러가 실행되었고, 두 번재 사진의 서버에서는 동일한 시간대에 스케줄러가 실행되지 않은 것을 확인할 수 있었습니다. 

1분 후에 두 번째 사진의 서버가 스케줄러가 동작하는 것을 확인할 수 있었습니다.

## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> 현재 스케줄러 두 개에 대해서 분산 락 처리를 하였습니다. 
> 서현님께서 작성하신 Job Step이 재실행 되지 않을 것 같아서 이 부분 수정했습니다. [참고](https://velog.io/@milkskfk5677/Spring-Batch-COMPLETE-%EB%90%9C-Step-%EC%9E%AC%EC%8B%A4%ED%96%89-%ED%95%98%EA%B8%B0)


