### PR TITLE
[feat] 이미지 저장 S3 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,9 @@ dependencies {
     implementation 'org.springframework.session:spring-session-data-redis'
 
     implementation 'org.springframework.boot:spring-boot-devtools'
+
+    // Amazon S3
+    implementation 'software.amazon.awssdk:s3:2.30.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/programmers/signalbuddy/domain/member/controller/MemberController.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package org.programmers.signalbuddy.domain.member.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.programmers.signalbuddy.domain.admin.service.AdminService;
@@ -26,7 +27,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("api/members")
@@ -50,10 +53,15 @@ public class MemberController {
     @ApiResponse(responseCode = "200", description = "수정 성공")
     @PatchMapping("{id}")
     public ResponseEntity<MemberResponse> updateMember(@PathVariable Long id,
-        @Validated @RequestBody MemberUpdateRequest memberUpdateRequest) {
-        // TODO : 사용자 이미지 저장 방식 정해지면 수정 필요
+        @RequestPart(value = "email", required = false) String email,
+        @RequestPart(value = "nickname", required = false) String nickname,
+        @RequestPart(value = "password", required = false) String password,
+        @RequestPart(value = "imageFile", required = false) MultipartFile imageFile,
+        HttpServletRequest request) {
+        final MemberUpdateRequest memberUpdateRequest = MemberUpdateRequest.builder().email(email)
+            .nickname(nickname).password(password).imageFile(imageFile).build();
         log.info("id : {}, UpdateRequest: {}", id, memberUpdateRequest);
-        final MemberResponse updated = memberService.updateMember(id, memberUpdateRequest);
+        final MemberResponse updated = memberService.updateMember(id, memberUpdateRequest, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(updated);
     }
 

--- a/src/main/java/org/programmers/signalbuddy/domain/member/dto/MemberUpdateRequest.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/member/dto/MemberUpdateRequest.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Builder
@@ -27,6 +28,6 @@ public class MemberUpdateRequest {
     @Schema(description = "닉네임", requiredMode = RequiredMode.NOT_REQUIRED, defaultValue = "Nickname")
     private String nickname;
 
-    @Schema(description = "프로필 사진", requiredMode = RequiredMode.NOT_REQUIRED, defaultValue = "test.png")
-    private String profileImageUrl;
+    @Schema(description = "프로필 사진 파일", requiredMode = RequiredMode.NOT_REQUIRED, defaultValue = "profile-img.png")
+    private MultipartFile imageFile;
 }

--- a/src/main/java/org/programmers/signalbuddy/domain/member/entity/Member.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/member/entity/Member.java
@@ -60,7 +60,7 @@ public class Member extends BaseTimeEntity {
         return !user.getMemberId().equals(member.getMemberId());
     }
 
-    public void updateMember(MemberUpdateRequest request, String encodedPassword) {
+    public void updateMember(MemberUpdateRequest request, String encodedPassword, String profileImageUrl) {
         if (request.getEmail() != null) {
             this.email = request.getEmail();
         }
@@ -70,8 +70,8 @@ public class Member extends BaseTimeEntity {
         if (request.getNickname() != null) {
             this.nickname = request.getNickname();
         }
-        if (request.getProfileImageUrl() != null) {
-            this.profileImageUrl = request.getProfileImageUrl();
+        if (profileImageUrl != null) {
+            this.profileImageUrl = profileImageUrl;
         }
     }
 

--- a/src/main/java/org/programmers/signalbuddy/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/member/exception/MemberErrorCode.java
@@ -12,9 +12,11 @@ public enum MemberErrorCode implements ErrorCode {
 
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, 60000, "해당 사용자를 찾을 수 없습니다."),
     ALREADY_EXIST_EMAIL(HttpStatus.CONFLICT, 60001, "이미 존재하는 이메일 입니다."),
-    PROFILE_IMAGE_LOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 60002, "프로필 이미지 로드 중 오류가 발생했습니다."),
+    PROFILE_IMAGE_LOAD_ERROR_NOT_EXIST_FILE(HttpStatus.INTERNAL_SERVER_ERROR, 60002, "유효하지 않은 URL 또는 읽을 수 없는 파일입니다."),
     WITHDRAWN_MEMBER(HttpStatus.FORBIDDEN, 60003, "탈퇴한 회원입니다."),
-    PROFILE_IMAGE_UPLOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, 60004, "프로필 이미지 저장 중 오류가 발생했습니다.");
+    PROFILE_IMAGE_UPLOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, 60004, "프로필 이미지 저장 중 오류가 발생했습니다."),
+    PROFILE_IMAGE_LOAD_ERROR_INVALID_URL(HttpStatus.INTERNAL_SERVER_ERROR, 60005, "URL 생성 중 오류가 발생했습니다."),
+    S3_UPLOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, 60006, "S3 업로드 중 오류가 발생했습니다.");
 
     private HttpStatus httpStatus;
     private int code;

--- a/src/main/java/org/programmers/signalbuddy/domain/member/service/AwsFileService.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/member/service/AwsFileService.java
@@ -1,0 +1,108 @@
+package org.programmers.signalbuddy.domain.member.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class AwsFileService {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.folder}")
+    private String profileImageDir;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${default.profile.image.path}")
+    private String defaultProfileImagePath;
+
+    /**
+     * S3에서 프로필 이미지를 가져옵니다.
+     *
+     * @param filename S3에 저장된 파일명
+     * @return Resource 객체
+     * @throws IllegalStateException 유효하지 않은 URL 또는 읽을 수 없는 파일인 경우
+     */
+    public Resource getProfileImage(String filename) {
+        final String filePath = profileImageDir + filename;
+        final URL url = generateFileUrl(filePath);
+        final Resource resource = new UrlResource(url);
+
+        if (!resource.exists() || !resource.isReadable()) {
+            log.error("유효하지 않은 파일: {}", filePath);
+            throw new IllegalStateException("유효하지 않은 URL 또는 읽을 수 없는 파일입니다.");
+        }
+
+        return resource;
+    }
+
+    /**
+     * S3에 프로필 이미지를 저장합니다.
+     *
+     * @param profileImage 업로드할 프로필 이미지 파일
+     * @return 저장된 파일 이름
+     * @throws IllegalStateException 파일 업로드 중 오류가 발생한 경우
+     */
+    public String saveProfileImage(MultipartFile profileImage) {
+        final String uniqueFilename = UUID.randomUUID() + "-" + profileImage.getOriginalFilename();
+        final String key = profileImageDir + uniqueFilename;
+
+        try (InputStream inputStream = profileImage.getInputStream()) {
+            uploadToS3(key, inputStream, profileImage.getContentType(), profileImage.getSize());
+            return uniqueFilename;
+        } catch (IOException e) {
+            log.error("파일 업로드 실패: {}", profileImage.getOriginalFilename(), e);
+            throw new IllegalStateException("파일 업로드 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    /**
+     * S3 URL 생성
+     *
+     * @param key S3 객체 키
+     * @return URL 객체
+     */
+    private URL generateFileUrl(String key) {
+        final GetUrlRequest request = GetUrlRequest.builder().bucket(bucket).key(key).build();
+        return s3Client.utilities().getUrl(request);
+    }
+
+    /**
+     * S3에 파일 업로드
+     *
+     * @param key         S3 객체 키
+     * @param inputStream 업로드할 파일의 InputStream
+     * @param contentType 파일의 Content-Type
+     * @param size        파일 크기
+     * @throws IllegalStateException S3에 파일 업로드 중 오류가 발생한 경우
+     */
+    private void uploadToS3(String key, InputStream inputStream, String contentType, long size) {
+        try {
+            final PutObjectRequest putObjectRequest = PutObjectRequest.builder().bucket(bucket)
+                .key(key).contentType(contentType).build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(inputStream, size));
+        } catch (Exception e) {
+            log.error("파일 업로드 실패: {}", key, e);
+            throw new IllegalStateException("S3에 파일 업로드 중 오류가 발생했습니다. 객체 키: " + key, e);
+        }
+    }
+}

--- a/src/main/java/org/programmers/signalbuddy/domain/member/service/AwsFileService.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/member/service/AwsFileService.java
@@ -7,6 +7,8 @@ import java.net.URL;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.programmers.signalbuddy.domain.member.exception.MemberErrorCode;
+import org.programmers.signalbuddy.global.exception.BusinessException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
@@ -51,13 +53,13 @@ public class AwsFileService {
 
             if (!resource.exists() || !resource.isReadable()) {
                 log.error("유효하지 않은 파일: {}", filePath);
-                throw new IllegalStateException("유효하지 않은 URL 또는 읽을 수 없는 파일입니다.");
+                throw new BusinessException(MemberErrorCode.PROFILE_IMAGE_LOAD_ERROR_NOT_EXIST_FILE);
             }
 
             return resource;
         } catch (MalformedURLException e) {
             log.error("URL 생성 실패: {}", filePath, e);
-            throw new IllegalStateException("URL 생성 중 오류가 발생했습니다.", e);
+            throw new BusinessException(MemberErrorCode.PROFILE_IMAGE_LOAD_ERROR_INVALID_URL);
         }
     }
 
@@ -77,7 +79,7 @@ public class AwsFileService {
             return uniqueFilename;
         } catch (IOException e) {
             log.error("파일 업로드 실패: {}", profileImage.getOriginalFilename(), e);
-            throw new IllegalStateException("파일 업로드 중 오류가 발생했습니다.", e);
+            throw new BusinessException(MemberErrorCode.PROFILE_IMAGE_UPLOAD_FAILURE);
         }
     }
 
@@ -109,7 +111,7 @@ public class AwsFileService {
             s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(inputStream, size));
         } catch (Exception e) {
             log.error("파일 업로드 실패: {}", key, e);
-            throw new IllegalStateException("S3에 파일 업로드 중 오류가 발생했습니다. 객체 키: " + key, e);
+            throw new BusinessException(MemberErrorCode.S3_UPLOAD_FAILURE);
         }
     }
 

--- a/src/main/java/org/programmers/signalbuddy/domain/member/service/MemberService.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/member/service/MemberService.java
@@ -26,7 +26,6 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class MemberService {
 
-    private static final String NO_PROFILE_IMAGE = "none";
     private final MemberRepository memberRepository;
     private final AwsFileService awsFileService;
     private BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
@@ -87,13 +86,12 @@ public class MemberService {
 
     public Resource getProfileImage(String filename) {
         try {
-            if (NO_PROFILE_IMAGE.equals(filename)) {
+            if (filename.isEmpty()) {
                 return new ClassPathResource(defaultProfileImagePath);
             }
             return awsFileService.getProfileImage(filename);
-
-        } catch (IllegalStateException e) {
-            throw new BusinessException(MemberErrorCode.PROFILE_IMAGE_LOAD_ERROR);
+        } catch (BusinessException e) {
+            return new ClassPathResource(defaultProfileImagePath);
         }
     }
 

--- a/src/main/java/org/programmers/signalbuddy/global/config/S3Config.java
+++ b/src/main/java/org/programmers/signalbuddy/global/config/S3Config.java
@@ -1,0 +1,27 @@
+package org.programmers.signalbuddy.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder().region(Region.AP_NORTHEAST_2) // 한국 리전
+            .credentialsProvider(
+                StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+            .build();
+    }
+}

--- a/src/main/resources/static/css/member/info.css
+++ b/src/main/resources/static/css/member/info.css
@@ -66,3 +66,30 @@
   display: flex;
   justify-content: space-evenly;
 }
+
+.camera-btn {
+  position: absolute;
+  right: 0px;
+  bottom: 0px;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: none;
+  background-color: white;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+}
+
+.profile-preview {
+  position: relative;
+  height: 140px;
+}
+
+.camera-btn img {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
+}

--- a/src/main/resources/templates/member/edit.html
+++ b/src/main/resources/templates/member/edit.html
@@ -19,26 +19,37 @@
     <section class="flex-1 bg-white shadow rounded-md ml-6 p-8"><h2
         class="font-title text-neutral-950 text-xl mb-8">계정 관리</h2>
       <div class="flex items-center justify-center mb-6">
-        <img alt="Profile" class="rounded-full profile-img"
-             th:src="${'/api/members/files/' + user.profileImageUrl}">
+        <div class="profile-preview">
+          <img alt="Profile" class="rounded-full profile-img" id="profileImg"
+               th:src="${'/api/members/files/' + user.profileImageUrl}">
+          <input accept="image/*" id="fileInput" name="profileImageUrl"
+                 onchange="previewImage(event)" style="display:none;" type="file">
+          <button class="camera-btn"
+                  onclick="event.preventDefault(); document.getElementById('fileInput').click();">
+            <img class="upload-button" src="/images/camera-icon.png">
+          </button>
+        </div>
       </div>
       <div class="space-y-4">
         <div class="input-box">
           <div class="flex flex-col input-value">
             <label class="text-neutral-600 text-sm mb-1">이메일
-              <input class="w-full border border-neutral-300 p-2 rounded-md text-sm text-neutral-600"
+              <input
+                  class="w-full border border-neutral-300 p-2 rounded-md text-sm text-neutral-600"
                   id="email" th:value="${user.email}" type="text"/>
             </label>
           </div>
           <div class="flex flex-col input-value">
             <label class="text-neutral-600 text-sm mb-1">닉네임
-              <input class="w-full border border-neutral-300 p-2 rounded-md text-sm text-neutral-600"
+              <input
+                  class="w-full border border-neutral-300 p-2 rounded-md text-sm text-neutral-600"
                   id="nickname" th:value="${user.nickname}" type="text"/>
             </label>
           </div>
           <div class="flex flex-col input-value">
             <label class="text-neutral-600 text-sm mb-1">비밀번호
-              <input class="w-full border border-neutral-300 p-2 rounded-md text-sm text-neutral-600"
+              <input
+                  class="w-full border border-neutral-300 p-2 rounded-md text-sm text-neutral-600"
                   id="password" type="password"/>
             </label>
           </div>
@@ -60,25 +71,33 @@
     const nickname = document.querySelector('#nickname').value;
     const password = document.querySelector('#password').value.trim();
     const id = btn.dataset.id;
+    const fileInput = document.querySelector("#fileInput");
+    const file = fileInput.files[0];
 
-    const params = {
-      email,
-      nickname
-    }
+    const formData = new FormData();
+
+    formData.append("email", email);
+    formData.append("nickname", nickname);
     if (password) {
-      params.password = password
+      formData.append("password", password);
     }
+    if (file) {
+      formData.append("imageFile", file);
+    }
+
     fetch(`/api/members/${id}`, {
       method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(params),
+      body: formData,
     })
     .then(response => {
       return response.json();
     })
     .then(data => {
+      if (data.code) {
+        console.log('업데이트 실패 : ', data)
+        alert('수정이 실패했습니다.')
+        return;
+      }
       console.log('업데이트 성공:', data);
       alert("수정이 완료되었습니다.")
       window.location.href = `/members`
@@ -88,6 +107,19 @@
     });
   }
 
+  function previewImage(event) {
+    const fileInput = event.target;
+    const reader = new FileReader();
+
+    reader.onload = function (e) {
+      const preview = document.getElementById('profileImg');
+      preview.src = e.target.result;
+    };
+
+    if (fileInput.files[0]) {
+      reader.readAsDataURL(fileInput.files[0]);
+    }
+  }
 </script>
 </body>
 </html>

--- a/src/main/resources/templates/member/info.html
+++ b/src/main/resources/templates/member/info.html
@@ -20,6 +20,7 @@
       <h2 class="font-title text-neutral-950 text-xl mb-8">계정 관리</h2>
       <div class="flex items-center justify-center mb-6">
         <img alt="Profile" class="rounded-full profile-img"
+             onerror="this.src='/images/member/profile-icon.png';"
              th:src="${'/api/members/files/' + user.profileImageUrl}">
       </div>
       <form class="space-y-4">

--- a/src/test/java/org/programmers/signalbuddy/domain/member/service/AwsFileServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddy/domain/member/service/AwsFileServiceTest.java
@@ -1,0 +1,124 @@
+package org.programmers.signalbuddy.domain.member.service;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Utilities;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@ExtendWith(MockitoExtension.class)
+class AwsFileServiceTest {
+
+    @Mock
+    private S3Client s3Client;
+
+    @InjectMocks
+    private AwsFileService awsFileService;
+
+    @Test
+    @DisplayName("프로필 이미지 저장 성공 테스트")
+    void saveProfileImage_Success() throws IOException {
+        String fileName = "test-image.png";
+        MultipartFile mockFile = mock(MultipartFile.class);
+        InputStream mockInputStream = new ByteArrayInputStream("dummy content".getBytes());
+
+        when(mockFile.getOriginalFilename()).thenReturn(fileName);
+        when(mockFile.getInputStream()).thenReturn(mockInputStream);
+        when(mockFile.getContentType()).thenReturn("image/png");
+        when(mockFile.getSize()).thenReturn((long) "dummy content".length());
+
+        // Mock S3Client의 동작 설정
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+            .thenReturn(null); // putObject의 반환값을 지정
+
+        String result = awsFileService.saveProfileImage(mockFile);
+
+        assertNotNull(result);
+        assertTrue(result.contains(fileName));
+        verify(s3Client, times(1)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 불러오기 성공 테스트")
+    void getProfileImage_Success() throws MalformedURLException {
+        String fileName = "test-image.png";
+        String key = "profiles/" + fileName;
+        String bucketName = "test-bucket";
+
+        // Mock S3Utilities
+        S3Utilities mockUtilities = mock(S3Utilities.class);
+        URL mockUrl = new URL("https://example.com/" + key);
+        when(mockUtilities.getUrl(any(GetUrlRequest.class))).thenReturn(mockUrl);
+
+        // Mock S3Client
+        when(s3Client.utilities()).thenReturn(mockUtilities);
+
+        // bucket 과 profileImageDir에 값 넣기
+        ReflectionTestUtils.setField(awsFileService, "bucket", bucketName);
+        ReflectionTestUtils.setField(awsFileService, "profileImageDir", "profiles/");
+
+        // Spy AwsFileService, mock UrlResource 생성
+        AwsFileService spyService = spy(awsFileService);
+        UrlResource mockResource = mock(UrlResource.class);
+        when(mockResource.exists()).thenReturn(true);
+        when(mockResource.isReadable()).thenReturn(true);
+        doReturn(mockResource).when(spyService).createUrlResource(mockUrl);
+
+        Resource resource = spyService.getProfileImage(fileName);
+
+        assertNotNull(resource);
+        assertTrue(resource.exists());
+        assertTrue(resource.isReadable());
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 저장 실패 테스트")
+    void saveProfileImage_Fail() throws IOException {
+        // Given
+        String fileName = "test-image.png";
+        MultipartFile mockFile = mock(MultipartFile.class);
+        InputStream mockInputStream = new ByteArrayInputStream("dummy content".getBytes());
+
+        when(mockFile.getOriginalFilename()).thenReturn(fileName);
+        when(mockFile.getInputStream()).thenReturn(mockInputStream);
+        when(mockFile.getContentType()).thenReturn("image/png");
+        when(mockFile.getSize()).thenReturn((long) "dummy content".length());
+
+        // S3Client가 예외를 던지도록 설정
+        doThrow(new RuntimeException("S3 upload failed"))
+            .when(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
+            awsFileService.saveProfileImage(mockFile);
+        });
+
+        assertTrue(exception.getMessage().contains("S3에 파일 업로드 중 오류가 발생했습니다"));
+    }
+}

--- a/src/test/java/org/programmers/signalbuddy/domain/member/service/AwsFileServiceTest.java
+++ b/src/test/java/org/programmers/signalbuddy/domain/member/service/AwsFileServiceTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.programmers.signalbuddy.domain.member.exception.MemberErrorCode;
+import org.programmers.signalbuddy.global.exception.BusinessException;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -115,10 +117,11 @@ class AwsFileServiceTest {
         doThrow(new RuntimeException("S3 upload failed"))
             .when(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
 
-        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
             awsFileService.saveProfileImage(mockFile);
         });
 
-        assertTrue(exception.getMessage().contains("S3에 파일 업로드 중 오류가 발생했습니다"));
+        assertTrue(exception.getMessage().contains(MemberErrorCode.S3_UPLOAD_FAILURE.getMessage()));
+
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #144 


## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 `ex) [feat] ㅇㅇ 기능 추가`
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료
- [x] 🏗️ 빌드 성공
- [x] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> 이미지 저장 로직을 S3 저장 및 불러오기로 변경

## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->



## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> 회원 정보 수정 후에 세션 갱신 하는 로직을 새로 짰는데 이렇게 하는게 맞는 방법인지 잘 모르겠네요....
`MemberService` -> `updateSecurityContext` 부분입니다

