### PR TITLE
[fix] 탈퇴한 소셜로그인 가입자의 로그인을 차단

### DIFF
--- a/src/main/java/org/programmers/signalbuddy/global/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/org/programmers/signalbuddy/global/security/oauth/CustomOAuth2UserService.java
@@ -4,16 +4,18 @@ import lombok.RequiredArgsConstructor;
 import org.programmers.signalbuddy.domain.member.entity.Member;
 import org.programmers.signalbuddy.domain.member.entity.enums.MemberRole;
 import org.programmers.signalbuddy.domain.member.entity.enums.MemberStatus;
+import org.programmers.signalbuddy.domain.member.exception.MemberErrorCode;
 import org.programmers.signalbuddy.domain.member.repository.MemberRepository;
 import org.programmers.signalbuddy.domain.social.entity.SocialProvider;
 import org.programmers.signalbuddy.domain.social.repository.SocialProviderRepository;
+import org.programmers.signalbuddy.global.exception.BusinessException;
 import org.programmers.signalbuddy.global.security.oauth.response.GoogleResponse;
 import org.programmers.signalbuddy.global.security.oauth.response.KakaoResponse;
 import org.programmers.signalbuddy.global.security.oauth.response.NaverResponse;
 import org.programmers.signalbuddy.global.security.oauth.response.OAuth2Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.io.ClassPathResource;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -27,6 +29,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private static final Logger log = LoggerFactory.getLogger(CustomOAuth2UserService.class);
     private final MemberRepository memberRepository;
     private final SocialProviderRepository socialProviderRepository;
+
+    @Value("${default.profile.image.path}")
+    private String defaultProfileImagePath;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -56,12 +61,16 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 Member newMember = Member.builder()
                     .email(email)
                     .nickname(oAuth2Response.getName())
-                    .profileImageUrl("none")
+                    .profileImageUrl(defaultProfileImagePath)
                     .role(MemberRole.USER)
                     .memberStatus(MemberStatus.ACTIVITY)
                     .build();
                 return memberRepository.save(newMember);
             });
+
+        if(saveMember.getMemberStatus() == MemberStatus.WITHDRAWAL){
+            throw new BusinessException(MemberErrorCode.WITHDRAWN_MEMBER);
+        }
 
         // 이미 소셜이 저장되어 있는 경우, 중복 저장하지 않음.
         if(!socialProviderRepository.existsByOauthProviderAndSocialId(oAuth2Response.getProvider(), oAuth2Response.getProviderId())){


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #145 


## ✅ 체크리스트

- [ ] 🔀 PR 제목의 형식 맞추기 `ex) [feat] ㅇㅇ 기능 추가`
- [ ] 💡 이슈 등록
- [ ] 🏷️ 라벨 등록
- [ ] 🧹 불필요한 코드 제거
- [ ] 🧪 로컬 테스트 완료
- [ ] 🏗️ 빌드 성공
- [ ] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> 탈퇴 상태의 사용자가 로그인을 성공하지 못하도록 수정했습니다.


## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->



## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> 여기에 작성

