### PR TITLE
[feat] 배치 로그 삭제

### DIFF
--- a/src/main/java/org/programmers/signalbuddy/domain/like/batch/LikeBatchLogJobConfig.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/like/batch/LikeBatchLogJobConfig.java
@@ -1,0 +1,98 @@
+package org.programmers.signalbuddy.domain.like.batch;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import org.programmers.signalbuddy.global.batch.dto.BatchExecutionId;
+import org.programmers.signalbuddy.global.batch.repository.BatchJdbcRepository;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.batch.item.database.Order;
+import org.springframework.batch.item.database.builder.JdbcPagingItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class LikeBatchLogJobConfig {
+
+    private final DataSource dataSource;
+    private final BatchJdbcRepository batchJdbcRepository;
+
+    @Value("${schedule.like-log-delete-job.expired-minutes}")
+    private String expiredMinutes;    // 로그의 유효 시간 (분)
+
+    private static final int CHUNK_SIZE = 100;
+
+    @Bean
+    public Job likeBatchLogDeleteJob(JobRepository jobRepository,
+        PlatformTransactionManager transactionManager) {
+
+        return new JobBuilder("likeBatchLogDeleteJob", jobRepository)
+            .incrementer(new RunIdIncrementer())    // 동일한 파라미터를 다시 실행
+            .start(deleteLikeLogBatch(jobRepository, transactionManager))
+            .build();
+    }
+
+    @Bean
+    @JobScope
+    public Step deleteLikeLogBatch(JobRepository jobRepository,
+        PlatformTransactionManager transactionManager) {
+
+        return new StepBuilder("deleteLikeLogBatch", jobRepository)
+            .<BatchExecutionId, BatchExecutionId>chunk(CHUNK_SIZE, transactionManager)
+            .reader(executionPagingReader())
+            .writer(deleteLog())
+            .allowStartIfComplete(true) // COMPLETED 되어도 재실행에 포함시키기
+            .build();
+    }
+
+    @Bean
+    @StepScope
+    public JdbcPagingItemReader<BatchExecutionId> executionPagingReader() {
+        return new JdbcPagingItemReaderBuilder<BatchExecutionId>()
+            .name("executionPagingReader")
+            .dataSource(dataSource)
+            .selectClause("SELECT STEP_EXECUTION_ID, JOB_EXECUTION_ID")
+            .fromClause("FROM BATCH_STEP_EXECUTION")
+            .whereClause("WHERE STEP_NAME IN ('updateLikeBatch', 'deleteLikeLogBatch')"
+                + "AND START_TIME < :threshold")
+            .parameterValues(Map.of("threshold",
+                LocalDateTime.now().minusMinutes(Long.parseLong(expiredMinutes))))
+            .sortKeys(Map.of("STEP_EXECUTION_ID", Order.ASCENDING))
+            .pageSize(CHUNK_SIZE)
+            .rowMapper(new BeanPropertyRowMapper<>(BatchExecutionId.class))
+            .build();
+    }
+
+    @Bean
+    @StepScope
+    public ItemWriter<BatchExecutionId> deleteLog() {
+        return (chunk) -> {
+            @SuppressWarnings("unchecked")
+            List<BatchExecutionId> executionIds = (List<BatchExecutionId>) chunk.getItems();
+
+            batchJdbcRepository.deleteAllByStepExecutionIdInBatch(
+                "BATCH_STEP_EXECUTION_CONTEXT", executionIds);
+            batchJdbcRepository.deleteAllByStepExecutionIdInBatch(
+                "BATCH_STEP_EXECUTION", executionIds);
+            batchJdbcRepository.deleteAllByJobExecutionIdInBatch(
+                "BATCH_JOB_EXECUTION_CONTEXT", executionIds);
+            batchJdbcRepository.deleteAllByJobExecutionIdInBatch(
+                "BATCH_JOB_EXECUTION", executionIds);
+        };
+    }
+}

--- a/src/main/java/org/programmers/signalbuddy/domain/like/batch/LikeLogDeleteJobScheduler.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/like/batch/LikeLogDeleteJobScheduler.java
@@ -1,0 +1,29 @@
+package org.programmers.signalbuddy.domain.like.batch;
+
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Configuration
+@RequiredArgsConstructor
+public class LikeLogDeleteJobScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job likeBatchLogDeleteJob;
+
+    @Scheduled(cron = "${schedule.like-log-delete-job.cron}")
+    @SchedulerLock(
+        name = "LikeLogDeleteJobScheduler",
+        lockAtMostFor = "${schedule.like-log-delete-job.lockAtMostFor}",
+        lockAtLeastFor = "${schedule.like-log-delete-job.lockAtLeastFor}")
+    public void runJob() throws Exception {
+        JobParameters params = new JobParametersBuilder()
+            .toJobParameters();
+        jobLauncher.run(likeBatchLogDeleteJob, params);
+    }
+}

--- a/src/main/java/org/programmers/signalbuddy/global/batch/dto/BatchExecutionId.java
+++ b/src/main/java/org/programmers/signalbuddy/global/batch/dto/BatchExecutionId.java
@@ -1,0 +1,15 @@
+package org.programmers.signalbuddy.global.batch.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BatchExecutionId {
+
+    private Long jobExecutionId;
+    private Long stepExecutionId;
+}

--- a/src/main/java/org/programmers/signalbuddy/global/batch/job/BatchLogJob.java
+++ b/src/main/java/org/programmers/signalbuddy/global/batch/job/BatchLogJob.java
@@ -1,0 +1,42 @@
+package org.programmers.signalbuddy.global.batch.job;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class BatchLogJob {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Bean
+    public Job oldBatchLogDeleteJob(JobRepository jobRepository,
+        PlatformTransactionManager transactionManager) {
+
+        return new JobBuilder("oldBatchLogDeleteJob", jobRepository)
+            .incrementer(new RunIdIncrementer())    // 동일한 파라미터를 다시 실행
+            .start(deleteOldLog(jobRepository, transactionManager))
+            .build();
+    }
+
+    @Bean
+    @JobScope
+    public Step deleteOldLog(JobRepository jobRepository,
+        PlatformTransactionManager transactionManager) {
+
+        return new StepBuilder("deleteOldLog", jobRepository)
+            .tasklet(new OldLogDeleteTasklet(jdbcTemplate), transactionManager)
+            .allowStartIfComplete(true) // COMPLETED 되어도 재실행에 포함시키기
+            .build();
+    }
+}

--- a/src/main/java/org/programmers/signalbuddy/global/batch/job/BatchLogJobScheduler.java
+++ b/src/main/java/org/programmers/signalbuddy/global/batch/job/BatchLogJobScheduler.java
@@ -1,0 +1,29 @@
+package org.programmers.signalbuddy.global.batch.job;
+
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Configuration
+@RequiredArgsConstructor
+public class BatchLogJobScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job oldBatchLogDeleteJob;
+
+    @Scheduled(cron = "0 0 3 * * ?")
+    @SchedulerLock(
+        name = "BatchLogJobScheduler",
+        lockAtMostFor = "23h",
+        lockAtLeastFor = "23h")
+    public void runJob() throws Exception {
+        JobParameters params = new JobParametersBuilder()
+            .toJobParameters();
+        jobLauncher.run(oldBatchLogDeleteJob, params);
+    }
+}

--- a/src/main/java/org/programmers/signalbuddy/global/batch/job/OldLogDeleteTasklet.java
+++ b/src/main/java/org/programmers/signalbuddy/global/batch/job/OldLogDeleteTasklet.java
@@ -1,0 +1,40 @@
+package org.programmers.signalbuddy.global.batch.job;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+public class OldLogDeleteTasklet implements Tasklet {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    private static final long EXPIRED_DATE = 14; // 로그의 유효 기간 (일)
+
+    // Batch Meta Table 로그 삭제 쿼리들 (순서대로 진행해야 함)
+    private static final List<String> DELETE_QUERIES = List.of(
+        "DELETE FROM BATCH_STEP_EXECUTION_CONTEXT WHERE STEP_EXECUTION_ID IN ( SELECT STEP_EXECUTION_ID FROM BATCH_STEP_EXECUTION WHERE START_TIME < ?)",
+        "DELETE FROM BATCH_STEP_EXECUTION WHERE START_TIME < ?",
+        "DELETE FROM BATCH_JOB_EXECUTION_CONTEXT WHERE JOB_EXECUTION_ID IN ( SELECT JOB_EXECUTION_ID FROM BATCH_JOB_EXECUTION WHERE CREATE_TIME < ?)",
+        "DELETE FROM BATCH_JOB_EXECUTION_PARAMS WHERE JOB_EXECUTION_ID IN ( SELECT JOB_EXECUTION_ID FROM BATCH_JOB_EXECUTION WHERE CREATE_TIME < ?)",
+        "DELETE FROM BATCH_JOB_EXECUTION WHERE CREATE_TIME < ?",
+        "DELETE FROM BATCH_JOB_INSTANCE WHERE JOB_INSTANCE_ID NOT IN (SELECT JOB_INSTANCE_ID FROM BATCH_JOB_EXECUTION)");
+
+    @Override
+    @Transactional
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        Date oldDate = Date.valueOf(LocalDate.now().minusDays(EXPIRED_DATE));
+
+        for (String query : DELETE_QUERIES) {
+            jdbcTemplate.update(query, ps -> ps.setDate(1, oldDate));
+        }
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/org/programmers/signalbuddy/global/batch/repository/BatchJdbcRepository.java
+++ b/src/main/java/org/programmers/signalbuddy/global/batch/repository/BatchJdbcRepository.java
@@ -1,0 +1,63 @@
+package org.programmers.signalbuddy.global.batch.repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.programmers.signalbuddy.global.batch.dto.BatchExecutionId;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BatchJdbcRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    /**
+     * STEP_EXECUTION_ID로 STEP 관련 BATCH META TABLE의 데이터를 벌크 연산으로 삭제
+     *
+     * @param batchTableName 삭제할 배치 테이블명
+     * @param executionIds  STEP_EXECUTION_ID, JOB_EXECUTION_ID 목록
+     */
+    public void deleteAllByStepExecutionIdInBatch(String batchTableName, List<BatchExecutionId> executionIds) {
+        String sql = "DELETE FROM " + batchTableName + " WHERE STEP_EXECUTION_ID = ?";
+
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                Long stepExecutionId = executionIds.get(i).getStepExecutionId();
+                ps.setLong(1, stepExecutionId);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return executionIds.size();
+            }
+        });
+    }
+
+    /**
+     * JOB_EXECUTION_ID로 JOB 관련 BATCH META TABLE의 데이터를 벌크 연산으로 삭제
+     *
+     * @param batchTableName 삭제할 배치 테이블명
+     * @param executionIds  STEP_EXECUTION_ID, JOB_EXECUTION_ID 목록
+     */
+    public void deleteAllByJobExecutionIdInBatch(String batchTableName, List<BatchExecutionId> executionIds) {
+        String sql = "DELETE FROM " + batchTableName + " WHERE JOB_EXECUTION_ID = ?";
+
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                Long jobExecutionId = executionIds.get(i).getJobExecutionId();
+                ps.setLong(1, jobExecutionId);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return executionIds.size();
+            }
+        });
+    }
+}

--- a/src/test/java/org/programmers/signalbuddy/domain/like/batch/LikeBatchLogJobConfigTest.java
+++ b/src/test/java/org/programmers/signalbuddy/domain/like/batch/LikeBatchLogJobConfigTest.java
@@ -1,0 +1,32 @@
+package org.programmers.signalbuddy.domain.like.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.programmers.signalbuddy.global.support.BatchTest;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class LikeBatchLogJobConfigTest extends BatchTest {
+
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+
+    @Autowired
+    private Job likeBatchLogDeleteJob;
+
+    @DisplayName("좋아요 배치 작업의 로그 삭제 잡 실행")
+    @Test
+    void likeBatchLogDeleteJob() throws Exception {
+        // when
+        jobLauncherTestUtils.setJob(likeBatchLogDeleteJob);
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob();
+
+        // then
+        assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+    }
+}

--- a/src/test/java/org/programmers/signalbuddy/global/batch/job/BatchLogJobTest.java
+++ b/src/test/java/org/programmers/signalbuddy/global/batch/job/BatchLogJobTest.java
@@ -1,0 +1,32 @@
+package org.programmers.signalbuddy.global.batch.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.programmers.signalbuddy.global.support.BatchTest;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class BatchLogJobTest extends BatchTest {
+
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+
+    @Autowired
+    private Job oldBatchLogDeleteJob;
+
+    @DisplayName("14일 이상된 배치 작업의 로그를 삭제하는 잡 실행")
+    @Test
+    void oldBatchLogDeleteJob() throws Exception {
+        // when
+        jobLauncherTestUtils.setJob(oldBatchLogDeleteJob);
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob();
+
+        // then
+        assertThat(jobExecution.getExitStatus()).isEqualTo(ExitStatus.COMPLETED);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -37,3 +37,8 @@ schedule:
     cron: "2 0 3 * * ?" # 매일 1시 2초마다
     lockAtMostFor: 23h  # 오류 발생 시 락을 유지하는 시간 (작업의 실행 시간보다 길게 하는 게 좋음)
     lockAtLeastFor: 23h # 락을 유지하는 최소 시간 (스케줄러 시간보다 짧게 지정하는 게 좋음)
+  like-log-delete-job:
+    cron: "0 0 0/10 * * ?" # 매 1시간마다
+    lockAtMostFor: 9h  # 오류 발생 시 락을 유지하는 시간 (작업의 실행 시간보다 길게 하는 게 좋음)
+    lockAtLeastFor: 9h # 락을 유지하는 최소 시간 (스케줄러 시간보다 짧게 지정하는 게 좋음)
+    expired-minutes: 1  # 좋아요 배치 로그의 유효 시간 (분)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #159 


## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 `ex) [feat] ㅇㅇ 기능 추가`
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료
- [x] 🏗️ 빌드 성공
- [x] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> 좋아요 요청 배치 로그를 1시간 주기로 삭제하는 배치 잡을 만들었습니다.
> 그 외 배치 로그는 3시마다 14일이상 경과된 로그만 삭제 되게 하는 배치 잡을 만들었습니다.

## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->



## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> 배치 로그를 다루는 건 테스트 코드 실행 시 데이터가 필요해서 로컬로 테스트 해보았고, 정상적으로 동작했습니다.
> 테스트 코드로 작성한 것은 해당 잡이 정상적으로 실행되는지만 확인할 수 있도록 했습니다.

