### PR TITLE
[fix] 피드백 삭제 전에 좋아요 데이터 삭제하기

### DIFF
--- a/src/main/java/org/programmers/signalbuddy/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/feedback/service/FeedbackService.java
@@ -10,6 +10,7 @@ import org.programmers.signalbuddy.domain.feedback.entity.Feedback;
 import org.programmers.signalbuddy.domain.feedback.exception.FeedbackErrorCode;
 import org.programmers.signalbuddy.domain.feedback.repository.FeedbackJdbcRepository;
 import org.programmers.signalbuddy.domain.feedback.repository.FeedbackRepository;
+import org.programmers.signalbuddy.domain.like.repository.LikeRepository;
 import org.programmers.signalbuddy.domain.member.entity.Member;
 import org.programmers.signalbuddy.domain.member.exception.MemberErrorCode;
 import org.programmers.signalbuddy.domain.member.repository.MemberRepository;
@@ -30,6 +31,7 @@ public class FeedbackService {
     private final MemberRepository memberRepository;
     private final FeedbackJdbcRepository feedbackJdbcRepository;
     private final CommentRepository commentRepository;
+    private final LikeRepository likeRepository;
 
     public PageResponse<FeedbackResponse> searchFeedbackList(Pageable pageable, Long answerStatus) {
         Page<FeedbackResponse> responsePage = feedbackRepository.findAllByActiveMembers(pageable,
@@ -92,6 +94,7 @@ public class FeedbackService {
         }
 
         commentRepository.deleteAllByFeedbackId(feedbackId);
+        likeRepository.deleteAllByFeedbackId(feedbackId);
         feedbackRepository.deleteById(feedbackId);
     }
 

--- a/src/main/java/org/programmers/signalbuddy/domain/like/repository/LikeRepository.java
+++ b/src/main/java/org/programmers/signalbuddy/domain/like/repository/LikeRepository.java
@@ -2,6 +2,7 @@ package org.programmers.signalbuddy.domain.like.repository;
 
 import org.programmers.signalbuddy.domain.like.entity.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -14,4 +15,8 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
         + "WHERE l.member.memberId = :memberId AND l.feedback.feedbackId = :feedbackId")
     boolean existsByMemberAndFeedback(@Param("memberId") Long memberId,
         @Param("feedbackId") Long feedbackId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM likes l WHERE l.feedback.feedbackId = :feedbackId")
+    void deleteAllByFeedbackId(@Param("feedbackId") Long feedbackId);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #163 


## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 `ex) [feat] ㅇㅇ 기능 추가`
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료
- [x] 🏗️ 빌드 성공
- [x] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> 피드백 삭제 시, 좋아요 데이터도 함께 삭제되어 정상적으로 삭제되도록 함


## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->



## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> 

